### PR TITLE
Adding required headers to Sonarr requests

### DIFF
--- a/Sonarr/Sonarr.php
+++ b/Sonarr/Sonarr.php
@@ -13,7 +13,10 @@ class Sonarr extends \App\SupportedApps implements \App\EnhancedApps {
 
     public function test()
     {
-        $test = parent::appTest($this->url('system/status'));
+        $attrs = [
+            'headers'  => ['Accept' => 'application/json']
+        ];
+        $test = parent::appTest($this->url('system/status'), $attrs);
         echo $test->status;
     }
 
@@ -21,9 +24,13 @@ class Sonarr extends \App\SupportedApps implements \App\EnhancedApps {
     {
         $status = 'inactive';
         $data = [];
-
-        $missing = json_decode(parent::execute($this->url('wanted/missing'))->getBody());
-        $queue = json_decode(parent::execute($this->url('queue'))->getBody());
+        $attrs = [
+            'headers'  => ['Accept' => 'application/json']
+        ];
+        
+        
+        $missing = json_decode(parent::execute($this->url('wanted/missing'), $attrs)->getBody());
+        $queue = json_decode(parent::execute($this->url('queue'), $attrs)->getBody());
 
         $data = [];
 


### PR DESCRIPTION
The Accept header is required for API requests in the next version of Sonarr (current preview version). The current version of Sonarr seems to work fine with the header so should be safe to add now instead of waiting for the preview release to go mainstream.