### PR TITLE
Upgrade Traefik enhanced app to support Traefik v2

### DIFF
--- a/Traefik/Traefik.php
+++ b/Traefik/Traefik.php
@@ -1,40 +1,162 @@
 <?php namespace App\SupportedApps\Traefik;
 
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Client;
+use Illuminate\Support\Collection;
+
 class Traefik extends \App\SupportedApps implements \App\EnhancedApps {
 
-    public $config;
+    public function getRequestAttrs()
+    {
+        $username = $this->getConfigValue('username', null);
+        $password = $this->getConfigValue('password', null);
+        $ignoreTls = $this->getConfigValue('ignore_tls', false);
 
-    //protected $login_first = true; // Uncomment if api requests need to be authed first
-    //protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
+        $isLoginNeeded =
+            !is_null($username) && !empty($username)
+            && !is_null($password) && !empty($password);
 
-    function __construct() {
-        //$this->jar = new \GuzzleHttp\Cookie\CookieJar; // Uncomment if cookies need to be set
+        $attrs['headers'] = [ 'Accept' => 'application/json'];
+        if($isLoginNeeded) {
+            $attrs['auth'] = [ $username, $password ];
+        }
+        if($ignoreTls) {
+            $attrs['verify'] = false;
+        }
+
+        return $attrs;
     }
 
     public function test()
     {
-        $test = parent::appTest($this->url('health'));
+        $attrs = $this->getRequestAttrs();
+        $test = parent::appTest($this->url('api/version'), $attrs);
+
         echo $test->status;
     }
 
     public function livestats()
     {
-        $status = 'inactive';
-        $res = parent::execute($this->url('health'));
-        $details = json_decode($res->getBody());
+        $apiEndpoints = collect([
+            'httpRouters' => 'api/http/routers',
+            'httpServices' => 'api/http/services',
+            'tcpRouters' => 'api/tcp/routers',
+            'tcpServices' => 'api/tcp/services'
+        ]);
 
-        $data = [];
+        $status = 'active';
+        $attrs = $this->getRequestAttrs();
 
-        $avg_response_time = $details->average_response_time_sec ?? 0;
-        $time = $avg_response_time*1000;
-        $data['time_output'] = ($time > 0) ? number_format($time, 2).'<span>ms</span>' : 'Unknown';
 
+        $responses = $apiEndpoints->mapWithKeys(function ($endpoint, $key) use ($attrs) {
+            $response = parent::execute($this->url($endpoint), $attrs);
+            $body = json_decode($response->getBody());
+            $bodyCollection = collect($body);
+
+            return [ $key => [
+                'data' => $bodyCollection->filter(function ($value, $key) { return $value->status === 'enabled'; })->count(),
+                'total' => $bodyCollection->count(),
+            ] ];
+        });
+
+
+        $data = $this->getViewData($this->getConfigValue('fields', 'E'), $responses);
         return parent::getLiveStats($status, $data);
-        
     }
+
+    public function getViewData($config, $responses)
+    {
+        $nullValue = [ 'data' => 0, 'total' => 0 ];
+
+        switch ($config) {
+            /* HTTP routers/services only */
+            case 'H':
+                return [
+                    'left' => [
+                        'title' => 'Routers',
+                        'data' => $responses->get('httpRouters', $nullValue)['data'],
+                        'total' => $responses->get('httpRouters', $nullValue)['total'],
+                    ],
+                    'right' => [
+                        'title' => 'Services',
+                        'data' => $responses->get('httpServices', $nullValue)['data'],
+                        'total' => $responses->get('httpServices', $nullValue)['total'],
+                    ],
+                ];
+                break;
+
+            /* TCP routers/services only */
+            case 'T':
+                return [
+                    'left' => [
+                        'title' => 'Routers',
+                        'data' => $responses->get('tcpRouters', $nullValue)['data'],
+                        'total' => $responses->get('tcpRouters', $nullValue)['total'],
+                    ],
+                    'right' => [
+                        'title' => 'Services',
+                        'data' => $responses->get('tcpServices', $nullValue)['data'],
+                        'total' => $responses->get('tcpServices', $nullValue)['total'],
+                    ],
+                ];
+
+            /* Routers only */
+            case 'R':
+                return [
+                    'left' => [
+                        'title' => 'HTTP',
+                        'data' => $responses->get('httpRouters', $nullValue)['data'],
+                        'total' => $responses->get('httpRouters', $nullValue)['total'],
+                    ],
+                    'right' => [
+                        'title' => 'TCP',
+                        'data' => $responses->get('tcpRouters', $nullValue)['data'],
+                        'total' => $responses->get('tcpRouters', $nullValue)['total'],
+                    ],
+                ];
+
+            /* Services only */
+            case 'S':
+                return [
+                    'left' => [
+                        'title' => 'HTTP',
+                        'data' => $responses->get('httpServices', $nullValue)['data'],
+                        'total' => $responses->get('httpServices', $nullValue)['total'],
+                    ],
+                    'right' => [
+                        'title' => 'TCP',
+                        'data' => $responses->get('tcpServices', $nullValue)['data'],
+                        'total' => $responses->get('tcpServices', $nullValue)['total'],
+                    ],
+                ];
+            
+            /* Everything */
+            default:
+                return [
+                    'left' => [
+                        'title' => 'Routers',
+                        'data' => $responses->get('httpRouters', $nullValue)['data'] + $responses->get('tcpRouters', $nullValue)['data'],
+                        'total' => $responses->get('httpRouters', $nullValue)['total'] + $responses->get('tcpRouters', $nullValue)['total'],
+                    ],
+                    'right' => [
+                        'title' => 'Services',
+                        'data' => $responses->get('httpServices', $nullValue)['data'] + $responses->get('tcpServices', $nullValue)['data'],
+                        'total' => $responses->get('httpServices', $nullValue)['total'] + $responses->get('tcpServices', $nullValue)['total'],
+                    ],
+                ];
+        }
+    }
+
     public function url($endpoint)
     {
         $api_url = parent::normaliseurl($this->config->url).$endpoint;
         return $api_url;
     }
+
+    public function getConfigValue($key, $default=null)
+    {
+        return (isset($this->config) && isset($this->config->$key)) ? $this->config->$key : $default;
+    }
+
 }
+

--- a/Traefik/config.blade.php
+++ b/Traefik/config.blade.php
@@ -1,8 +1,36 @@
 <h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
-<div class="items">
+<div class="items" style="flex-wrap: wrap;">
     <div class="input">
         <label>{{ strtoupper(__('app.url')) }}</label>
         {!! Form::text('config[override_url]', (isset($item) ? $item->getconfig()->override_url : null), array('placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control')) !!}
+    </div>
+    <div class="input">
+        <label>Which fields to show</label>
+        {!! Form::select('config[fields]', [ 'E' => 'Everything', 'H' => 'HTTP only', 'T' => 'TCP only', 'R' => 'Routers', 'S' => 'Services' ],
+                            (isset($item) && isset($item->getconfig()->fields) ? $item->getconfig()->fields : null), array('id' => 'fields', 'class' => 'form-control config-item')) !!}
+    </div>
+    <div class="input">
+        <label>Skip TLS verification</label>
+        <div class="toggleinput" style="margin-top: 26px; padding-left: 15px;">
+            {!! Form::hidden('config[ignore_tls]', 0, [ 'class' => 'config-item', 'data-config' => 'ignore_tls' ]) !!}
+            <label class="switch">
+                <?php
+                $checked = false;
+                if(isset($item) && !empty($item) && isset($item->getconfig()->ignore_tls)) $checked = $item->getconfig()->ignore_tls;
+                $set_checked = ($checked) ? ' checked="checked"' : '';
+                ?>
+                <input type="checkbox" class="config-item" data-config="ignore_tls" name="config[ignore_tls]" value="1"<?php echo $set_checked;?> />
+                <span class="slider round"></span>
+            </label>
+        </div>
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.username') }}</label>
+        {!! Form::text('config[username]', (isset($item) ? $item->getconfig()->username : null), array('placeholder' => __('app.apps.username'), 'data-config' => 'username', 'class' => 'form-control config-item')) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.password') }}</label>
+        {!! Form::text('config[password]', (isset($item) ? $item->getconfig()->password : null), array('placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item')) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Traefik/livestats.blade.php
+++ b/Traefik/livestats.blade.php
@@ -1,6 +1,4 @@
 <ul class="livestats">
-    <li>
-        <span class="title">Avg. Response Time</span>
-        <strong>{!! $time_output !!}</strong>
-    </li>
+    <li><span class="title">{!! $left['title'] !!}</span><strong>{!! $left['data'] !!}<span>/{!! $left['total'] !!}</span></strong></li>
+    <li><span class="title">{!! $right['title'] !!}</span><strong>{!! $right['data'] !!}<span>/{!! $right['total'] !!}</span></strong></li>
 </ul>


### PR DESCRIPTION
Add configuration for the Traefik v2 API (#118).
This app in no longer compatible with Traefik v1 /health endpoint.

In order to support Traefik v2, we need to access its API, the `/health` endpoint is no more.

## Configuration
A whole new configuration has been introduced:
- **override_url**: API url in case it differs from the dashboard url, , leave blank otherwise
- **fields**: Change which data to display when pinned
- **ignore_tls**: Ignore TLS certificate validation result when querying the API
- **username**: Basic Authentication username in case API is protected, leave blank otherwise
- **password**: Basic Authentication password in case API is protected, leave blank otherwise

**Important:** While testing the configuration from the item configuration page, the TLS certificate is **ALWAYS** ignored, I couldn't get the checkbox to register correctly when clicking the *TEST* button.

### Fields
| Option | Left Column | Right Column |
|--|--|--|
| *Everything* | HTTP Routers + TCP Routers | HTTP Services + TCP Services |
| *HTTP only* | HTTP Routers | HTTP Services |
| *TCP only* | TCP Routers | TCP Services |
| *Routers* | HTTP Routers | TCP Routers |
| *Services* | HTTP Services | TCP Services |

## Example
Here is part of my current configuration to get it working:

*traefik-static.yml*
```
[...]
api: {}


entryPoints:
  http:
    address: ":80"

  https:
    address: ":443"
[...]
```
*traefik-dynamic.yml*
```
tls:
  options:
    default:
      minVersion: VersionTLS13
    insecure:
      minVersion: VersionTLS12


http:
  routers:
    [...]
    api:
      rule: "[...]"
      entryPoints:
        - https
      middlewares:
        - api-auth
      service: "api@internal"
      tls: {}
    api-insecure:
      rule: "Host(`traefik`)"
      entryPoints:
        - https
      middlewares:
        - api-auth
      service: "api@internal"
      tls:
        options: insecure

  [...]

  middlewares:
    api-auth:
      basicAuth:
        [...]
        removeHeader: true
[...]
```
*Heimdall Item configuration*

| Option | Value |
|--|--|
| URL | `http://traefik/`<br/>*The containers are on the same internal docker network,<br>so I can just use the container's name* |
| Fields | `Everything` |
| Skip TLS verification | `true` |
| Username | `<***>`<br/>*My Basic Authentication username* |
| Password | `<***>`<br/>*My Basic Authentication password* |

*Note:* The API request url, even if not exposed, gets the schema upgraded from HTTP to HTTPS, so I need to ignore the TLS certificate when I make the requests (I know it's my certificate, so no problem).
