### PR TITLE
ruTorrent: Hide idle speed

### DIFF
--- a/ruTorrent/livestats.blade.php
+++ b/ruTorrent/livestats.blade.php
@@ -1,10 +1,14 @@
 <ul class="livestats">
+    @if($down_rate != "0 B/s")
     <li style="width:50%;">
         <span class="title">DOWN ↓</span>
         <strong>{!! $down_rate !!}</strong>
     </li>
+    @endif
+    @if($up_rate != "0 B/s")
     <li>
         <span class="title">UP ↑</span>
         <strong>{!! $up_rate !!}</strong>
     </li>
+    @endif
 </ul>

--- a/ruTorrent/ruTorrent.php
+++ b/ruTorrent/ruTorrent.php
@@ -83,6 +83,6 @@ class ruTorrent extends \App\SupportedApps implements \App\EnhancedApps {
 
         $bytes /= pow(1024, $pow); 
 
-        return round($bytes, $precision) . ' <span>' . $units[$pow] . '/s</span>';
+        return round($bytes, $precision) . ' ' . $units[$pow] . '/s';
     }
 }


### PR DESCRIPTION
Hiding idle speeds on live stats at the request of the original author.