### PR TITLE
Updated for qBitTorrent API v2

### DIFF
--- a/qBittorrent/qBittorrent.php
+++ b/qBittorrent/qBittorrent.php
@@ -1,5 +1,9 @@
 <?php namespace App\SupportedApps\qBittorrent;
 
+# qBitTorrent v4.2.0 onwards enforces the use of API v2.
+# API Documentation:
+# https://github.com/qbittorrent/qBittorrent/wiki/Web-API-Documentation#authentication
+
 class qBittorrent extends \App\SupportedApps implements \App\EnhancedApps {
 
     public $config;
@@ -17,7 +21,8 @@ class qBittorrent extends \App\SupportedApps implements \App\EnhancedApps {
         if($test->getStatusCode() === 200) {
             echo $test->getStatusCode();
         }
-        $test = parent::appTest($this->url('version/api'));
+        #$test = parent::appTest($this->url('version/api'));
+        $test = parent::appTest($this->url('api/v2/app/version'));
         echo $test->status;
     }
 
@@ -30,7 +35,8 @@ class qBittorrent extends \App\SupportedApps implements \App\EnhancedApps {
             'cookies' => $this->jar,
             'headers' => ['content-type' => 'application/x-www-form-urlencoded']
         ];
-        return parent::execute($this->url('login'), $attrs, false, 'POST');
+        #return parent::execute($this->url('login'), $attrs, false, 'POST');
+        return parent::execute($this->url('/api/v2/auth/login'), $attrs, false, 'POST');
     }
 
     public function livestats()
@@ -40,7 +46,8 @@ class qBittorrent extends \App\SupportedApps implements \App\EnhancedApps {
         $attrs = [
                 'cookies' => $this->jar
         ];
-        $res = parent::execute($this->url('query/torrents'), $attrs);
+        #$res = parent::execute($this->url('query/torrents'), $attrs);
+        $res = parent::execute($this->url('api/v2/torrents/info'), $attrs);
         $details = json_decode($res->getBody());
 
         $data = [];

--- a/qBittorrent/qBittorrent.php
+++ b/qBittorrent/qBittorrent.php
@@ -36,7 +36,7 @@ class qBittorrent extends \App\SupportedApps implements \App\EnhancedApps {
             'headers' => ['content-type' => 'application/x-www-form-urlencoded']
         ];
         #return parent::execute($this->url('login'), $attrs, false, 'POST');
-        return parent::execute($this->url('/api/v2/auth/login'), $attrs, false, 'POST');
+        return parent::execute($this->url('api/v2/auth/login'), $attrs, false, 'POST');
     }
 
     public function livestats()


### PR DESCRIPTION
Addresses linuxserver/Heimdall-Apps#146

As per release notes here (https://www.qbittorrent.org/news.php) v4.2.0 enforces modern API endpoints:
> WEBUI: Drop legacy WebAPI support (glassez)

I can't get the login piece to work though, works when testing with curl but not when running via PHP.  Workaround is to white-list the access to local IPs using the qBt preferences.