### PR TITLE
Bugfix: fix url() format

### DIFF
--- a/CouchPotato/CouchPotato.php
+++ b/CouchPotato/CouchPotato.php
@@ -34,7 +34,7 @@ class CouchPotato extends \App\SupportedApps implements \App\EnhancedApps {
     }
     public function url($endpoint)
     {
-        $api_url = parent::normaliseurl($this->config->url).'/api/'.$this->config->apikey.'/'.$endpoint;
+        $api_url = parent::normaliseurl($this->config->url).'api/'.$this->config->apikey.'/'.$endpoint;
         return $api_url;
     }
 }


### PR DESCRIPTION
extra forward slash following normaliseurl()