### PR TITLE
Update app.json

### DIFF
--- a/Deluge/app.json
+++ b/Deluge/app.json
@@ -5,6 +5,45 @@
     "license": "GNU General Public License v3.0 only",
     "description": "Deluge is a BitTorrent client written in Python. Deluge is cross-platform, using a front and back end architecture where libtorrent, a software library written in C++ which provides the application's networking logic, is connected to one of various front ends through the project's own Python bindings",
     "enhanced": true,
+    "config": {
+        "auth_payload": {
+            "method": 'auth.login',
+            "id": 1,
+            "params": [":password:"]
+         },
+        "type": "apikey",
+        "stats": [{
+            "name": "Queue",
+            "url": ":url:api?output=json&apikey=:apikey:&mode=queue",
+            "key": "queue.sizeleft",
+            "filter": "size",
+            "updateOnChange": "Yes",
+            "suffix": ""
+        }, {
+            "name": "Speed",
+            "url": ":url:api?output=json&apikey=:apikey:&mode=queue",
+            "key": "queue.speed",
+            "filter": "speed",
+            "updateOnChange": "Yes",
+            "suffix": ""
+        }],
+        "stat1": {
+            "name": "Queue",
+            "url": ":url:api?output=json&apikey=:apikey:&mode=queue",
+            "key": "queue.sizeleft",
+            "filter": "size",
+            "updateOnChange": "Yes",
+            "suffix": ""
+        },
+        "stat2": {
+            "name": "Speed",
+            "url": ":url:api?output=json&apikey=:apikey:&mode=queue",
+            "key": "queue.speed",
+            "filter": "speed",
+            "updateOnChange": "Yes",
+            "suffix": ""
+        }
+    }
     "tile_background": "dark",
     "icon": "deluge.png"
 }

--- a/Deluge/app.json
+++ b/Deluge/app.json
@@ -43,7 +43,7 @@
             "updateOnChange": "Yes",
             "suffix": ""
         }
-    }
+    },
     "tile_background": "dark",
     "icon": "deluge.png"
 }


### PR DESCRIPTION
Adding an 'auth_payload' to be POSTed before login. I don't think this is going to work for every app - there will be different auth mechanisms that are not supported by this signature, but this is a start.

Adding stats as an array to switch stats to '1 & 2', to array based, so we can test a new format for stats