### PR TITLE
Update Shinobi's website URL

### DIFF
--- a/Shinobi/app.json
+++ b/Shinobi/app.json
@@ -1,7 +1,7 @@
 {
     "appid": "dcf2874559e0304e2811c796cb873ae9aac07fa2",
     "name": "Shinobi",
-    "website": "shinobi.video",
+    "website": "https://shinobi.video",
     "license": "GNU Public License 3.0",
     "description": "An open-source CCTV NVR for recording, monitoring, and streaming modern IP cameras.  Lightweight, extremely compatible and simple to use.",
     "enhanced": false,


### PR DESCRIPTION
Include https:// scheme, otherwise the URL was shown on the https://apps.heimdall.site/applications/foundation page as being a relative URL: https://apps.heimdall.site/applications/shinobi.video