### PR TITLE
Fixing app.json

### DIFF
--- a/Deluge/app.json
+++ b/Deluge/app.json
@@ -7,7 +7,7 @@
     "enhanced": true,
     "config": {
         "auth_payload": {
-            "method": 'auth.login',
+            "method": "auth.login",
             "id": 1,
             "params": [":password:"]
          },


### PR DESCRIPTION
Used single quotes - causing invalid JSON evaluation. Changed to double quotes