### PR TITLE
Fix the error after empty API creation.

### DIFF
--- a/Emby/config.blade.php
+++ b/Emby/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
     <label>Stats to show</label>
-        {!! Form::select('config[availablestats][]', App\SupportedApps\Emby\Emby::getAvailableStats(), isset($item)?$item->getConfig()->availablestats:null, array('multiple'=>'multiple')) !!}
+        {!! Form::select('config[availablestats][]', App\SupportedApps\Emby\Emby::getAvailableStats(), isset($item) ? ($item->getConfig()->availablestats ?? null) : null, array('multiple'=>'multiple')) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Jellyfin/config.blade.php
+++ b/Jellyfin/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
     <label>Stats to show</label>
-        {!! Form::select('config[availablestats][]', App\SupportedApps\Jellyfin\Jellyfin::getAvailableStats(), isset($item)?$item->getConfig()->availablestats:null, array('multiple'=>'multiple')) !!}
+     {!! Form::select('config[availablestats][]', App\SupportedApps\Jellyfin\Jellyfin::getAvailableStats(), isset($item) ? ($item->getConfig()->availablestats ?? null) : null, array('multiple'=>'multiple')) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>


### PR DESCRIPTION
The line code copied from NextCloud config.blade.php, that fix the error querying null/empty additional stats. Works on emby and jellyfin.

 {!! Form::select('config[availablestats][]', App\SupportedApps\APP_NAME\APP_NAME::getAvailableStats(), isset($item) ? ($item->getConfig()->availablestats ?? null) : null, array('multiple'=>'multiple')) !!}
