### PR TITLE
Jellyfin bugfix: availablestats undefined

### DIFF
--- a/Jellyfin/config.blade.php
+++ b/Jellyfin/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
     <label>Stats to show</label>
-        {!! Form::select('config[availablestats][]', App\SupportedApps\Jellyfin\Jellyfin::getAvailableStats(), isset($item)?$item->getConfig()->availablestats:null, array('multiple'=>'multiple')) !!}
+        {!! Form::select('config[availablestats][]', App\SupportedApps\Jellyfin\Jellyfin::getAvailableStats(), isset($item) ? ($item->getConfig()->availablestats ?? null) : null, array('multiple'=>'multiple')) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>


### PR DESCRIPTION
On first run, the variable `availablestats` is not yet defined and throws an error when trying to access it.
The bugfix is a safeguard against that.
See Emby, Bookstack and Nextcloud's implementation of the same select box; this fix is taken directly from there.