### PR TITLE
Enhanced Kodi app

### DIFF
--- a/Kodi/Kodi.php
+++ b/Kodi/Kodi.php
@@ -1,5 +1,59 @@
 <?php namespace App\SupportedApps\Kodi;
 
-class Kodi extends \App\SupportedApps {
+class Kodi extends \App\SupportedApps implements \App\EnhancedApps {
+    public $config;
 
+    function __construct() {}
+
+    public function url($endpoint)
+    {
+        $api_url = parent::normaliseurl($this->config->url) . 'jsonrpc?request={"id":1,"jsonrpc":"2.0","method":"' . $endpoint . '"}';
+        return $api_url;
+    }
+
+    private function getAttrs() {
+        return [
+            'headers' => [
+                'Authorization' => 'Basic ' . base64_encode($this->config->username . ':' . $this->config->password),
+            ]
+        ];
+    }
+
+    public function test()
+    {
+        $test = parent::appTest($this->url('JSONRPC.Introspect'), $this->getAttrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = 'inactive';
+        $data = ['visiblestats' => []];
+        foreach($this->config->availablestats as $method) {
+            $res = parent::execute($this->url($method), $this->getAttrs());
+            $result = json_decode($res->getBody());
+            if ( isset($result->result) && isset($result->result->limits) ) {
+                $stat = new \stdClass();
+                $stat->title = self::getAvailableStats()[$method];
+                $stat->value = $result->result->limits->total;
+                $data['visiblestats'][] = $stat;
+            }
+        }
+        return parent::getLiveStats($status, $data);
+    }
+
+    public static function getAvailableStats()
+    {
+        return [
+            'VideoLibrary.GetMovies' => 'Movies',
+            'VideoLibrary.GetMovieSets' => 'Movie Sets',
+            'VideoLibrary.GetTVShows' => 'TV Shows',
+            'VideoLibrary.GetEpisodes' => 'Episodes',
+            'PVR.GetRecordings' => 'PVR Rec',
+            'AudioLibrary.GetArtists' => 'Artists',
+            'AudioLibrary.GetAlbums' => 'Albums',
+            'AudioLibrary.GetSongs' => 'Songs',
+            'VideoLibrary.GetMusicVideos' => 'Music Vids',
+        ];
+    }
 }

--- a/Kodi/app.json
+++ b/Kodi/app.json
@@ -4,7 +4,7 @@
     "website": "https://kodi.tv/",
     "license": "GNU General Public License v1.0 or later",
     "description": "Kodi (formerly known as XBMC) is an award-winning free and open source (GPL) software media player and entertainment hub that can be installed on Linux, OSX, Windows, iOS and Android, featuring a 10-foot user interface for use with televisions and remote controls.",
-    "enhanced": false,
+    "enhanced": true,
     "tile_background": "dark",
     "icon": "kodi.png"
 }

--- a/Kodi/config.blade.php
+++ b/Kodi/config.blade.php
@@ -1,0 +1,22 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', null, array('placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control')) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.username') }}</label>
+        {!! Form::text('config[username]', null, array('placeholder' => __('app.apps.username'), 'data-config' => 'username', 'class' => 'form-control config-item')) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.password') }}</label>
+        {!! Form::password('config[password]', array('placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item')) !!}
+    </div>
+    <div class="input">
+    <label>Stats to show</label>
+        {!! Form::select('config[availablestats][]', App\SupportedApps\Kodi\Kodi::getAvailableStats(), isset($item) ? ($item->getConfig()->availablestats ?? null) : null, array('multiple'=>'multiple')) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+</div>

--- a/Kodi/livestats.blade.php
+++ b/Kodi/livestats.blade.php
@@ -1,0 +1,8 @@
+<ul class="livestats">
+    @foreach ($visiblestats as $stat)
+        <li>
+            <span class="title">{!! $stat->title !!}</span>
+            <strong>{!! $stat->value !!}</strong>
+        </li>
+    @endforeach
+</ul>

--- a/openmediavault/app.json
+++ b/openmediavault/app.json
@@ -4,7 +4,7 @@
     "website": "https://www.openmediavault.org/",
     "license": "GNU General Public License v3.0 only",
     "description": "openmediavault is the next generation network attached storage (NAS) solution based on Debian Linux.",
-    "enhanced": false,
+    "enhanced": true,
     "tile_background": "dark",
     "icon": "openmediavault.png"
 }

--- a/openmediavault/config.blade.php
+++ b/openmediavault/config.blade.php
@@ -1,0 +1,22 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', null, array('placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control')) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.username') }}</label>
+        {!! Form::text('config[username]', null, array('placeholder' => __('app.apps.username'), 'data-config' => 'username', 'class' => 'form-control config-item')) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.password') }}</label>
+        {!! Form::password('config[password]', array('placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item')) !!}
+    </div>
+    <div class="input">
+    <label>Stats to show</label>
+        {!! Form::select('config[availablestats][]', App\SupportedApps\openmediavault\openmediavault::getAvailableStats(), isset($item) ? ($item->getConfig()->availablestats ?? null) : null, array('multiple'=>'multiple')) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+</div>

--- a/openmediavault/livestats.blade.php
+++ b/openmediavault/livestats.blade.php
@@ -1,0 +1,8 @@
+<ul class="livestats">
+    @foreach ($visiblestats as $stat)
+    <li>
+        <span class="title">{!! $stat->title !!}</span>
+        <strong>{!! $stat->value !!}</strong>
+    </li>
+    @endforeach
+</ul>

--- a/openmediavault/openmediavault.php
+++ b/openmediavault/openmediavault.php
@@ -1,5 +1,99 @@
 <?php namespace App\SupportedApps\openmediavault;
+use Exception;
+use GuzzleHttp\Cookie\CookieJar;
 
-class openmediavault extends \App\SupportedApps {
+class openmediavault extends \App\SupportedApps implements \App\EnhancedApps {
+    public $config;
 
+    private $cookie;
+
+    function __construct() {
+        $this->cookie = new \GuzzleHttp\Cookie\CookieJar;
+    }
+
+    public function url($endpoint) {
+        $api_url = parent::normaliseurl($this->config->url) . 'rpc.php';
+        return $api_url;
+    }
+
+    private function request($service, $method, $params = []) {
+        $attrs = [
+            'json' => [
+                'service' => $service,
+                'method' => $method,
+                'params' => $params,
+            ],
+            'cookies' => $this->cookie,
+        ];
+
+        $result = parent::execute($this->url(false), $attrs, false, 'POST');
+        if (null === $result) {
+            throw new Exception("OMV error: Could not connect");
+        }
+
+        $response = json_decode($result->getBody());
+
+        if (is_null($response->response) && isset($response->error->message)) {
+            throw new Exception(sprintf('OMV error: %s', $response->error->message));
+        }
+        elseif (is_null($response->response)) {
+            throw new Exception('OMV error: Empty response');
+        }
+        return $response->response;
+    }
+
+    private function auth() {
+        $result = $this->request('session', 'login', ['username' => $this->config->username, 'password' => $this->config->password]);
+        return $result->authenticated;
+    }
+
+    public function test() {
+        try {
+            $token = $this->auth();
+            echo "Successfully communicated with the API";
+        } catch (Exception $err) {
+            echo $err->getMessage();
+        }
+    }
+
+    private function symbol($bool) {
+        return (true === $bool ? '&#10003;' : '&#10007;');
+    }
+
+    public function livestats() {
+        $status = 'inactive';
+        $token = $this->auth();
+        $data = ['visiblestats' => []];
+
+        $info = $this->request('system', 'getInformation');
+        $data['CPU'] = sprintf('%.1f%%', $info->cpuUsage );
+        $data['RAM'] = sprintf('%.1f%%', $info->memUsed / $info->memTotal * 100 );
+
+        $services = $this->request('services', 'getStatus');
+        foreach ($services->data as $service) {
+            $k = explode(' ', $service->title)[0];
+            $data[$k] = sprintf('%s | %s', $this->symbol($service->enabled), $this->symbol($service->running));
+        }
+
+        foreach ($this->config->availablestats as $stat) {
+            $newstat = new \stdClass;
+            $newstat->title = self::getAvailableStats()[$stat];
+            $newstat->value = $data[$stat];
+            $data['visiblestats'][] = $newstat;
+        }
+        $status = 'active';
+        return parent::getLiveStats($status, $data);
+    }
+
+    public static function getAvailableStats() {
+        return [
+            'CPU' => 'CPU',
+            'RAM' => 'RAM',
+            'NFS' => 'NFS',
+            'FTP' => 'FTP',
+            'RSync' => 'RSync',
+            'SMB/CIFS' => 'SMB/CIFS',
+            'SSH' => 'SSH',
+        ];
+    }
 }


### PR DESCRIPTION
Update Kodi to display library statistics.

![image](https://user-images.githubusercontent.com/1258597/116685131-3834d400-a9f5-11eb-9ce1-704abb1a2cab.png)

This application is a little more resource-heavy:
Kodi's JSON-RPC does not have a sort of "GetStatistics/GetCounts" call, so we need to call individual library components to get the total numbers. This can become network-heavy if you have a gigantic library, I guess.

To-Do: option to replace the library stats with "Now playing" info, in case there's an active player.