### PR TITLE
Fixed Bazarr tile to work with recent versions of the API (v0.9.4 or greater)

### DIFF
--- a/Bazarr/Bazarr.php
+++ b/Bazarr/Bazarr.php
@@ -28,15 +28,13 @@ class Bazarr extends \App\SupportedApps implements \App\EnhancedApps {
             'headers'  => ['Accept' => 'application/json']
         ];
         
-        
-        $movies = json_decode(parent::execute($this->url('badges_movies'), $attrs)->getBody());
-        $series = json_decode(parent::execute($this->url('badges_series'), $attrs)->getBody());
+        $badges = json_decode(parent::execute($this->url('badges'), $attrs)->getBody());
 
         $data = [];
 
-        if($movies || $series) {
-            $data['movies'] = $movies->missing_movies ?? 0;
-            $data['series'] = $series->missing_episodes ?? 0;
+        if($badges) {
+            $data['movies'] = $badges->movies ?? 0;
+            $data['series'] = $badges->episodes ?? 0;
         }
 
         return parent::getLiveStats($status, $data);

--- a/Bazarr/livestats.blade.php
+++ b/Bazarr/livestats.blade.php
@@ -1,10 +1,10 @@
 <ul class="livestats">
     <li>
-        <span class="title">Missing</span>
-        <strong>{!! $movies !!} Movies</strong>
+        <span class="title">Movies</span>
+        <strong>{!! $movies !!}</strong>
     </li>
     <li>
-        <span class="title">&nbsp;</span>
-        <strong>{!! $series !!} TV</strong>
+        <span class="title">Episodes</span>
+        <strong>{!! $series !!}</strong>
     </li>
 </ul>

--- a/Radarr/Radarr.php
+++ b/Radarr/Radarr.php
@@ -26,9 +26,7 @@ class Radarr extends \App\SupportedApps implements \App\EnhancedApps {
         $queue = json_decode(parent::execute($this->url('queue'))->getBody());
 
         $collect = collect($movies);
-        $missing = $collect->filter(function ($item) {
-            return $item->hasFile == false && $item->monitored == true;
-        });
+        $missing = $collect->where('hasFile', false);
 
         $data = [];
         if($missing || $queue) {

--- a/Radarr/Radarr.php
+++ b/Radarr/Radarr.php
@@ -26,7 +26,9 @@ class Radarr extends \App\SupportedApps implements \App\EnhancedApps {
         $queue = json_decode(parent::execute($this->url('queue'))->getBody());
 
         $collect = collect($movies);
-        $missing = $collect->where('hasFile', false);
+        $missing = $collect->filter(function ($item) {
+            return $item->hasFile == false && $item->monitored == true;
+        });
 
         $data = [];
         if($missing || $queue) {


### PR DESCRIPTION
Not backward compatible as the API had a complete rework in 0.9.4. More than 92% of users are using 0.9.5 or greater anyway. Those who aren't should upgrade as much of the providers are probably broken in their old versions.