### PR TITLE
Add custom endpoint to ruTorrent

### DIFF
--- a/ruTorrent/config.blade.php
+++ b/ruTorrent/config.blade.php
@@ -13,6 +13,10 @@
         {!! Form::input('password', 'config[password]', (isset($item) && isset($item->getconfig()->password) ? $item->getconfig()->password : null), array('placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item')) !!}
     </div>
     <div class="input">
+        <label>{{ strtoupper(__('app.apps.endpoint')) }}</label>
+        {!! Form::text('config[endpoint]', (isset($item) && isset($item->getconfig()->endpoint) ? $item->getconfig()->endpoint : null), array('placeholder' => __('app.apps.endpoint'), 'id' => 'endpoint', 'class' => 'form-control')) !!}
+    </div>
+    <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
     </div>
 </div>

--- a/ruTorrent/ruTorrent.php
+++ b/ruTorrent/ruTorrent.php
@@ -15,7 +15,7 @@ class ruTorrent extends \App\SupportedApps implements \App\EnhancedApps {
         $data = $this->getXMLRPCData('throttle.global_down.rate');
         if( !isset($data) || $data == 'Err' || $data == null || !is_object($data))
         {
-           echo 'There is an issue connecting to "' . $this->url('RPC2') . '". Please respect URL format "http(s)://IP:PORT". ' . $data;
+           echo 'There is an issue connecting to "' . $this->url($this->config->endpoint ?? 'RPC2') . '". Please respect URL format "http(s)://IP:PORT". ' . $data;
         }
         else
         {
@@ -55,7 +55,7 @@ class ruTorrent extends \App\SupportedApps implements \App\EnhancedApps {
         }
 
         try{
-            $res = parent::execute($this->url('RPC2'), $this->attrs, $this->vars);
+            $res = parent::execute($this->url($this->config->endpoint ?? 'RPC2'), $this->attrs, $this->vars);
         } catch(\GuzzleHttp\Exception\RequestException $e){
             return ''; // Connection failed, display default response
         }


### PR DESCRIPTION
Not all ruTorrent clients use `RPC2` as endpoint for RPC. With this additional setting, users can specify the endpoint to RPC.