### PR TITLE
Fix: Sonarr Enhanced missing items

### DIFF
--- a/Sonarr/Sonarr.php
+++ b/Sonarr/Sonarr.php
@@ -45,7 +45,7 @@ class Sonarr extends \App\SupportedApps implements \App\EnhancedApps {
 
     public function url($endpoint)
     {
-        $api_url = parent::normaliseurl($this->config->url).'api/v3/'.$endpoint.'?apikey='.$this->config->apikey;
+        $api_url = parent::normaliseurl($this->config->url).'api/v3/'.$endpoint.'?sortKey=series.title&apikey='.$this->config->apikey;
         return $api_url;
     }
 }

--- a/Sonarr/app.json
+++ b/Sonarr/app.json
@@ -11,14 +11,14 @@
         "type": "apikey",
         "stat1": {
             "name": "Missing",
-            "url": ":url:api/wanted/missing?apikey=:apikey:",
+            "url": ":url:api/v3/wanted/missing?sortKey=series.title&apikey=:apikey:",
             "key": "totalRecords",
             "filter": "none",
             "updateOnChange": "No"
         },
         "stat2": {
             "name": "Queue",
-            "url": ":url:api/queue?apikey=:apikey:",
+            "url": ":url:api/v3/queue?apikey=:apikey:",
             "key": null,
             "filter": "count",
             "updateOnChange": "No"


### PR DESCRIPTION
currently the `/api/v3/wanted/missing` endpoint returns an error, as a recent change requires sortKey to be passed to this.
Updating the call with a sortKey so that the value can be returned again.