### PR TITLE
Change Radarr to light as default

### DIFF
--- a/Radarr/app.json
+++ b/Radarr/app.json
@@ -5,7 +5,7 @@
     "license": "GNU General Public License v3.0 only",
     "description": "Radarr is an independent fork of Sonarr reworked for automatically downloading movies via Usenet and BitTorrent.\r\n\r\nThe project was inspired by other Usenet/BitTorrent movie downloaders such as CouchPotato.",
     "enhanced": true,
-    "tile_background": "dark",
+    "tile_background": "light",
     "icon": "radarr.png",
     "config": {
         "type": "apikey",


### PR DESCRIPTION
Changed Radarr to light as default as the Radarr logo is dark
![radarr light](https://user-images.githubusercontent.com/4478206/149405305-3e993d02-4555-4466-b8d4-7b3a75affe36.png)
![radarr dark](https://user-images.githubusercontent.com/4478206/149405308-c07bba01-5540-47b8-bf4a-0273d78355c0.png)
k