### PR TITLE
[Update] BookStack - Normalise "/" in url and add "pages"

### DIFF
--- a/Bookstack/Bookstack.php
+++ b/Bookstack/Bookstack.php
@@ -51,7 +51,7 @@ class Bookstack extends \App\SupportedApps implements \App\EnhancedApps {
 
     public function url($endpoint)
     {
-        $api_url = parent::normaliseurl($this->config->url).$endpoint;
+        $api_url = (rtrim(parent::normaliseurl($this->config->url),'/')).'/'.(ltrim($endpoint,'/'));
         return $api_url;
     }
 
@@ -60,6 +60,7 @@ class Bookstack extends \App\SupportedApps implements \App\EnhancedApps {
             'shelves'=>'Shelves',
             'books'=>'Books',
             'chapters'=>'Chapters',
+            'pages'=>'Pages',
         ];
     }
 }


### PR DESCRIPTION
This change fixes multiple forward-slashes in URL by trimming the provided URL and endpoint path and adding one between them - this makes the behaviour more consistent.
Also adds the "page" endpoint to return the total number of pages.