### PR TITLE
Fix Illegal string offset 'name' bug

### DIFF
--- a/openmediavault/config.blade.php
+++ b/openmediavault/config.blade.php
@@ -2,15 +2,15 @@
 <div class="items">
     <div class="input">
         <label>{{ strtoupper(__('app.url')) }}</label>
-        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+        {!! Form::text('config[override_url]', (isset($item) ? $item->getconfig()->override_url : null), ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
     </div>
     <div class="input">
         <label>{{ __('app.apps.username') }}</label>
-        {!! Form::text('config[username]', isset($item) ? $item->getconfig()->username : null, ['placeholder' => __('app.apps.username'), 'data-config' => 'username', 'class' => 'form-control config-item']) !!}
+        {!! Form::text('config[username]', (isset($item) ? $item->getconfig()->username : null), ['placeholder' => __('app.apps.username'), 'data-config' => 'username', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', (isset($item) ? $item->getconfig()->password : null), ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <label>Stats to show</label>


### PR DESCRIPTION
Similar to #172 , fixing issue linuxserver/Heimdall#433

I'm not sure why this keeps happening... `Form::password` seems to only pass the arguments along to `Form::input`
I guess that's more of a question/issue for Laravel FormBuilder.