### PR TITLE
Honor release status

### DIFF
--- a/Radarr/Radarr.php
+++ b/Radarr/Radarr.php
@@ -27,7 +27,7 @@ class Radarr extends \App\SupportedApps implements \App\EnhancedApps
 		$queue = json_decode(parent::execute($this->url("queue"))->getBody());
 
 		$collect = collect($movies);
-		$missing = $collect->where("hasFile", false);
+		$missing = $collect->where("hasFile", false)->where('isAvailable', true);
 
 		$data = [];
 		if ($missing || $queue) {


### PR DESCRIPTION
Made this change locally so that movies that aren't released yet aren't considered missing.

They are in a "wanted" state when radarr is aware of them but they haven't been released to your minimum target of (announced/in cinemas/released)

Personally I, like most, probably wait for "released", and I would like movies to not show as missing until my minimum release target is hit.

Queue is kind of useless, could replace with the inverse of missing (movies that have no files but are not released) and call them "watched", but at least doesn't misrepresent the radars status.