### PR TITLE
fix: Plex livestats

### DIFF
--- a/Plex/Plex.php
+++ b/Plex/Plex.php
@@ -28,6 +28,19 @@ class Plex extends \App\SupportedApps implements \App\EnhancedApps
 			$this->url("/library/recentlyAdded"),
 			$this->attrs()
 		);
+		$body = $res->getBody();
+        $xml = simplexml_load_string(
+        	$body,
+			"SimpleXMLElement",
+			LIBXML_NOCDATA | LIBXML_NOBLANKS
+		);
+
+		$data = [];
+
+		if ($xml) {
+			$data["recently_added"] = $xml["size"];
+			$status = "active";
+		}
 
 		$res = parent::execute($this->url("/library/onDeck"));
 

--- a/Plex/livestats.blade.php
+++ b/Plex/livestats.blade.php
@@ -1,11 +1,11 @@
 <ul class="livestats">
     <li>
         <span class="title">Recent</span>
-        <strong>{!! $recently_added !!}</strong>
+        <strong>{!! $recently_added ?? '' !!}</strong>
     </li>
     <li>
         <span class="title">On Deck</span>
-        <strong>{!! $on_deck !!}</strong>
+        <strong>{!! $on_deck ?? '' !!}</strong>
     </li>
 
 </ul>


### PR DESCRIPTION
Should fix #540

It seems [this commit](https://github.com/linuxserver/Heimdall-Apps/commit/8dc8d0dc206c570cde44bbbe1d1fecdb2a82f30f) accidentally removed the code to set the __recently_added__ variable. I added it back.

Also made the two template variables optional to avoid future errors.