### PR TITLE
feat: Don't send stored passwords for enhanced apps to the client.

### DIFF
--- a/AWX/config.blade.php
+++ b/AWX/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/AdGuardHome/config.blade.php
+++ b/AdGuardHome/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/AlarmPI/config.blade.php
+++ b/AlarmPI/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/ArchiSteamFarm/config.blade.php
+++ b/ArchiSteamFarm/config.blade.php
@@ -6,7 +6,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/AriaNg/config.blade.php
+++ b/AriaNg/config.blade.php
@@ -6,7 +6,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }} (secret token)</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/BlueIrisNVR/config.blade.php
+++ b/BlueIrisNVR/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::text('config[password]', null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Clash/config.blade.php
+++ b/Clash/config.blade.php
@@ -6,8 +6,8 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::text('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
-    </div>
+		{!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+	</div>
     <div class="input">
         <label>Selector to Display</label>
         {!! Form::text('config[sel_name]', isset($item) ? $item->getconfig()->sel_name : null, ['placeholder' => 'Proxy', 'data-config' => 'sel_name', 'class' => 'form-control config-item']) !!}

--- a/Deluge/config.blade.php
+++ b/Deluge/config.blade.php
@@ -6,7 +6,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Emby/config.blade.php
+++ b/Emby/config.blade.php
@@ -6,7 +6,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }} (secret token)</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <label>Stats to show</label>

--- a/Freenas/config.blade.php
+++ b/Freenas/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Ghost/config.blade.php
+++ b/Ghost/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Homebridge/config.blade.php
+++ b/Homebridge/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Jellyfin/config.blade.php
+++ b/Jellyfin/config.blade.php
@@ -6,7 +6,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }} (secret token)</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <label>Stats to show</label>

--- a/Jenkins/config.blade.php
+++ b/Jenkins/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Kodi/config.blade.php
+++ b/Kodi/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <label>Stats to show</label>

--- a/Komga/config.blade.php
+++ b/Komga/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Miniflux/config.blade.php
+++ b/Miniflux/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Monit/config.blade.php
+++ b/Monit/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Navidrome/config.blade.php
+++ b/Navidrome/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Nessus/config.blade.php
+++ b/Nessus/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Nextcloud/config.blade.php
+++ b/Nextcloud/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
         <small>Security &raquo; App Password</small>
     </div>
     <div class="input">

--- a/NginxProxyManager/config.blade.php
+++ b/NginxProxyManager/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Nzbget/config.blade.php
+++ b/Nzbget/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Portainer/config.blade.php
+++ b/Portainer/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::input('password','config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/RabbitMQ/config.blade.php
+++ b/RabbitMQ/config.blade.php
@@ -11,7 +11,7 @@
     </div>
     <div class="input">
         <label>Password</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Spotweb/config.blade.php
+++ b/Spotweb/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Stash/config.blade.php
+++ b/Stash/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Tar1090/config.blade.php
+++ b/Tar1090/config.blade.php
@@ -11,7 +11,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Traefik/config.blade.php
+++ b/Traefik/config.blade.php
@@ -34,7 +34,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Transmission/config.blade.php
+++ b/Transmission/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/UrBackup/config.blade.php
+++ b/UrBackup/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/Volumio/config.blade.php
+++ b/Volumio/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/oVirt/config.blade.php
+++ b/oVirt/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::text('config[password]', null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>

--- a/openmediavault/config.blade.php
+++ b/openmediavault/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <label>Stats to show</label>

--- a/qBittorrent/config.blade.php
+++ b/qBittorrent/config.blade.php
@@ -10,7 +10,7 @@
     </div>
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
-        {!! Form::password('config[password]', isset($item) ? $item->getconfig()->password : null, ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>


### PR DESCRIPTION
With the Laravel 8 upgrade and laravelcollective update to 6.x the FORM::Password method does not support the submission of a value anymore.

The patch introduces the input method instead to be backward compatible. Also removes the password from the form prefilling.