### PR TITLE
fix: increase poll intervals for Portainer, Transmission

### DIFF
--- a/Portainer/config.blade.php
+++ b/Portainer/config.blade.php
@@ -1,5 +1,6 @@
 <h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
 <div class="items">
+	<input type="hidden" data-config="dataonly" class="config-item" name="config[dataonly]" value="1" />
     <div class="input">
         <label>{{ strtoupper(__('app.url')) }}</label>
         {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}

--- a/Transmission/config.blade.php
+++ b/Transmission/config.blade.php
@@ -1,5 +1,6 @@
 <h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
 <div class="items">
+	<input type="hidden" data-config="dataonly" class="config-item" name="config[dataonly]" value="1" />
     <div class="input">
         <label>{{ strtoupper(__('app.url')) }}</label>
         {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}


### PR DESCRIPTION
Right now both apps will easily lock out the user when they are polled too often.