### PR TITLE
Update execute(...) call use correct argument types in Qbittorrent

### DIFF
--- a/qBittorrent/qBittorrent.php
+++ b/qBittorrent/qBittorrent.php
@@ -42,7 +42,7 @@ class qBittorrent extends \App\SupportedApps implements \App\EnhancedApps
 		return parent::execute(
 			$this->url("api/v2/auth/login"),
 			$attrs,
-			false,
+			null,
 			"POST"
 		);
 	}


### PR DESCRIPTION
## Description
Closes #564 

Adjusts call to `parent::execute()` to pass null as the third argument, rather than false. This prevents a `TypeError` from being thrown when ever the application attempts to pull live stats or test the API connection.