### PR TITLE
Use latest paperless fork and enhance the app

### DIFF
--- a/PaperlessNgx/PaperlessNgx.php
+++ b/PaperlessNgx/PaperlessNgx.php
@@ -1,0 +1,64 @@
+<?php namespace App\SupportedApps\PaperlessNgx;
+
+class PaperlessNgx extends \App\SupportedApps implements \App\EnhancedApps
+{
+	public $config;
+
+	function __construct()
+	{
+	}
+
+	public function getRequestAttrs()
+	{
+		$apikey = $this->getConfigValue("apikey", null);
+
+		$attrs["headers"] = [
+			"Accept" => "application/json",
+			"Authorization" => $apikey,
+		];
+
+		return $attrs;
+	}
+
+
+	public function getConfigValue($key, $default = null)
+	{
+		return isset($this->config) && isset($this->config->$key)
+			? $this->config->$key
+			: $default;
+	}
+
+	public function test()
+	{
+		$attrs = $this->getRequestAttrs();
+		$test = parent::appTest($this->url("documents"), $attrs);
+		echo $test->status;
+	}
+
+	public function livestats()
+	{
+		$status = "inactive";
+		$data = [];
+		$attrs = $this->getRequestAttrs();
+
+		$documents = json_decode(
+			parent::execute($this->url("documents"), $attrs)->getBody()
+		);
+
+		$data = [
+			"documentCount" => $documents->count ?? 0,
+		];
+
+		return parent::getLiveStats($status, $data);
+	}
+
+	public function url($endpoint)
+	{
+		$api_url =
+			parent::normaliseurl($this->config->url) .
+			"api/" .
+			$endpoint .
+			"/";
+		return $api_url;
+	}
+}

--- a/PaperlessNgx/app.json
+++ b/PaperlessNgx/app.json
@@ -1,0 +1,10 @@
+{
+  "appid": "23e9c842d2423902706ae92996554f6fbd92c502",
+  "name": "PaperlessNgx",
+  "website": "https://github.com/paperless-ngx/paperless-ngx",
+  "license": "GNU General Public License v3.0 only",
+  "description": "Paperless-ngx is a document management system that transforms your physical documents into a searchable online archive so you can keep, well, less paper.",
+  "enhanced": true,
+  "tile_background": "dark",
+  "icon": "paperlessngx.svg"
+}

--- a/PaperlessNgx/config.blade.php
+++ b/PaperlessNgx/config.blade.php
@@ -1,0 +1,14 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.apikey') }}</label>
+        {!! Form::text('config[apikey]', isset($item) ? $item->getconfig()->apikey : null, ['placeholder' => __('app.apps.apikey'), 'data-config' => 'apikey', 'class' => 'form-control config-item']) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+</div>

--- a/PaperlessNgx/livestats.blade.php
+++ b/PaperlessNgx/livestats.blade.php
@@ -1,0 +1,6 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Documents</span>
+        <strong>{!! $documentCount !!}</strong>
+    </li>
+</ul>

--- a/PaperlessNgx/paperlessngx.svg
+++ b/PaperlessNgx/paperlessngx.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="900"
+   height="900"
+   id="svg3923"
+   sodipodi:docname="square.svg"
+   inkscape:export-filename="/tmp/test.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="0.92.2 2405546, 2018-03-11">
+  <metadata
+     id="metadata3929">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3927" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2096"
+     id="namedview3925"
+     showgrid="false"
+     inkscape:zoom="1.1360927"
+     inkscape:cx="635.07139"
+     inkscape:cy="606.383"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g3921" />
+  <g
+     transform="matrix(10.638298,0,0,10.638298,106.38298,-206.38301)"
+     id="g3921">
+    <defs
+       id="SvgjsDefs1018" />
+    <g
+       id="SvgjsG1019"
+       featureKey="root"
+       style="fill:#ffffff" />
+    <g
+       id="SvgjsG1020"
+       featureKey="symbol1"
+       transform="matrix(0.10341565,0,0,0.10341565,-11.43874,18.048418)"
+       inkscape:export-filename="/tmp/test.png"
+       inkscape:export-xdpi="116.02285"
+       inkscape:export-ydpi="116.02285"
+       style="fill:#17541f">
+      <defs
+         id="defs3911" />
+      <g
+         id="g3915">
+        <path
+           d="M 231,798 C 227,779 219,741 218,741 49,640 69,465 125,365 c 12,126 235,213 105,367 -1,2 6,26 12,48 26,-44 65,-97 63,-102 C 145,288 645,258 749,16 c 47,234 -24,596 -426,688 -2,1 -73,126 -76,127 0,-2 -30,-1 -26,-11 2,-6 6,-14 10,-22 z M 330,625 C 267,476 452,312 544,271 356,439 324,564 330,625 Z m -104,79 c 51,-59 -9,-160 -45,-193 61,105 57,166 45,193 z"
+           style="fill:#17541f"
+           id="path3913"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The original paperless was discontinued by the author long time ago and even the first single person driven fork (paperless-ng) is discontinued.

The latest active fork is paperless-ngx and community driven.

I also made this an enhanced app. The tile now shows the document count if an api key is provided.