### PR TITLE
fix(): PaperlessNgx auth header

### DIFF
--- a/PaperlessNgx/PaperlessNgx.php
+++ b/PaperlessNgx/PaperlessNgx.php
@@ -14,7 +14,7 @@ class PaperlessNgx extends \App\SupportedApps implements \App\EnhancedApps
 
 		$attrs["headers"] = [
 			"Accept" => "application/json",
-			"Authorization" => $apikey,
+			"Authorization" => "Token " .  $apikey,
 		];
 
 		return $attrs;


### PR DESCRIPTION
@keriati sorry but somehow I pushed a version with a faulty auth header...