### PR TITLE
Fix typo in tar1090

### DIFF
--- a/Tar1090/Tar1090.php
+++ b/Tar1090/Tar1090.php
@@ -27,8 +27,8 @@ class Tar1090 extends \App\SupportedApps implements \App\EnhancedApps
 		$data = [];
 
 		if ($details) {
-			$data["aircaft_with_pos"] = number_format(
-				$details->aircaft_with_pos
+			$data["aircraft_with_pos"] = number_format(
+				$details->aircraft_with_pos
 			);
 			$data["aircraft_without_pos"] = number_format(
 				$details->aircraft_without_pos

--- a/Tar1090/livestats.blade.php
+++ b/Tar1090/livestats.blade.php
@@ -1,7 +1,7 @@
 <ul class="livestats">
     <li>
         <span class="title">Aircraft<br />with Pos</span>
-        <strong>{!! $aircaft_with_pos !!}</strong>
+        <strong>{!! $aircraft_with_pos !!}</strong>
     </li>
     <li>
         <span class="title">Aircraft<br />w/o Pos</span>


### PR DESCRIPTION
This will fix typo issues in tar1090 which causes the details not being shown.