### PR TITLE
fix(AVMFritzbox): increase call intervall

### DIFF
--- a/AVMFritzbox/AVMFritzbox.php
+++ b/AVMFritzbox/AVMFritzbox.php
@@ -125,7 +125,7 @@ class AVMFritzbox extends \App\SupportedApps implements \App\EnhancedApps
 
 	public function livestats()
 	{
-		$status = "inactive";
+		$status = "active";
 
         $statusInfo = parent::execute(
 			$this->url("statusInfo"),


### PR DESCRIPTION
I just switched to Heimdall 2.5.4 and noticed the queue change. Because of this I now want to set $status from inactive from active because the app pulls live bandwith data of the internet connection.