### PR TITLE
Updated Nightscout license

### DIFF
--- a/Nightscout/app.json
+++ b/Nightscout/app.json
@@ -2,7 +2,7 @@
     "appid": "b0193185a6e5fe70dd102f701db350fbd0e79aa5",
     "name": "Nightscout",
     "website": "https://nightscout.github.io",
-    "license": "Apache License 2.0",
+    "license": "GNU Affero General Public License v3.0",
     "description": "Nightscout (CGM in the Cloud) is an open source, DIY project that allows real time access to a CGM data via personal website, smartwatch viewers, or apps and widgets available for smartphones.",
     "enhanced": false,
     "tile_background": "dark",


### PR DESCRIPTION
Apologies, just noticed I'd used the wrong license for Nightscout as per: https://github.com/nightscout/cgm-remote-monitor/blob/master/LICENSE

Correcting license to GNU Affero General Public License v3.0
