### PR TITLE
feat: add pihole api password authentication

### DIFF
--- a/Pihole/Pihole.php
+++ b/Pihole/Pihole.php
@@ -5,7 +5,7 @@ class Pihole extends \App\SupportedApps implements \App\EnhancedApps
 	public $config;
 
 	//protected $login_first = true; // Uncomment if api requests need to be authed first
-	//protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
+	protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
 
 	function __construct()
 	{
@@ -14,14 +14,31 @@ class Pihole extends \App\SupportedApps implements \App\EnhancedApps
 
 	public function test()
 	{
-		$test = parent::appTest($this->url("api.php"));
-		echo $test->status;
+		$attrs = [
+			"body" => "pw=" . $this->config->password,
+			"headers" => [
+				"content-type" => "application/x-www-form-urlencoded"
+			],
+		];
+		$test = parent::appTest($this->url("api.php"), $attrs);
+		$data = json_decode($test->response);
+		if (empty($data)) {
+			echo "Failed: Invalid credentials";
+		} else {
+			echo $test->status;       
+		}
 	}
 
 	public function livestats()
 	{
 		$status = "inactive";
-		$res = parent::execute($this->url("api.php"));
+		$attrs = [
+			"body" => "pw=" . $this->config->password,
+			"headers" => [
+				"content-type" => "application/x-www-form-urlencoded"
+			],
+		];
+		$res = parent::execute($this->url("api.php"), $attrs);
 		$details = json_decode($res->getBody());
 
 		$data = [];

--- a/Pihole/config.blade.php
+++ b/Pihole/config.blade.php
@@ -1,9 +1,12 @@
 <h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
 <div class="items">
-    <input type="hidden" data-config="dataonly" class="config-item" name="config[dataonly]" value="1" />
     <div class="input">
         <label>{{ strtoupper(__('app.url')) }}</label>
         {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.password') }}</label>
+        {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>


### PR DESCRIPTION
tested on heimdall version: 2.4.13_13.0.7 and pihole version: 2022.12.1_8.0.10

pi-hole admin web UI + api can now be password protected since https://pi-hole.net/blog/2022/11/17/upcoming-changes-authentication-for-more-api-endpoints-required/#page-content. 

this option is required by default in the latest TrueCharts version of pihole
![image](https://user-images.githubusercontent.com/44654729/211349112-218aa6ba-50de-480b-bf59-26e0fcdae914.png)
![image](https://user-images.githubusercontent.com/44654729/211350764-4160c494-3f67-420b-8eed-653dd6799175.png)


yet the hemdall supported app for pihole had no config option for password. api would always return empty list `[]` when pihole password was configured. and no pihole live stats in dashboard.

this PR enables setting pihole admin password in Heimdall config
![image](https://user-images.githubusercontent.com/44654729/211351954-a3384480-39dc-4809-8db6-dda59fc5ee1f.png)

and correctly reports empty pihole API response as invalid credentials
![image](https://user-images.githubusercontent.com/44654729/211351641-0ac2fb9f-d71e-490a-beb8-4e31755a960f.png)

api responds correctly with pihole stats when correct admin password is set
![image](https://user-images.githubusercontent.com/44654729/211352611-ea6d2f71-15ba-49b4-937e-e168e22bc8a8.png)

**edit:** i guess this is resolved by #589? That PR uses api token hash instead of password.
