### PR TITLE
Radarr: Make missing stat more meaningful (2nd attempt)

### DIFF
--- a/Radarr/Radarr.php
+++ b/Radarr/Radarr.php
@@ -27,7 +27,7 @@ class Radarr extends \App\SupportedApps implements \App\EnhancedApps
 		$queue = json_decode(parent::execute($this->url("queue"))->getBody());
 
 		$collect = collect($movies);
-		$missing = $collect->where("hasFile", false);
+		$missing = $collect->where("monitored", true)->where("isAvailable", true)->where("hasFile", false);
 
 		$data = [];
 		if ($missing || $queue) {


### PR DESCRIPTION
Only display missing movies if they are available (therefore truely missing) and monitored.

In Radarr those show up as "Wanted" rather than missing (missing ignores the availability).

This is similar to #437 (without the merge conflicts).