### PR TITLE
Syncthing: Show remaining GB instead of bytes

### DIFF
--- a/Syncthing/livestats.blade.php
+++ b/Syncthing/livestats.blade.php
@@ -4,7 +4,7 @@
         <strong>{!! $needed_files !!}</strong>
     </li>
     <li>
-        <span class="title">Needed Bytes</span>
-        <strong>{!! $needed_bytes !!}</strong>
+        <span class="title">Needed Gigabytes</span>
+        <strong>{!! round($needed_bytes / 1073741824, 2) !!} GB</strong>
     </li>
 </ul>


### PR DESCRIPTION
Enhancement to the readability of the remaining file size in the WebUI.