### PR TITLE
moved the span tags to look better for the proxmox livestats blade.

### DIFF
--- a/Proxmox/livestats.blade.php
+++ b/Proxmox/livestats.blade.php
@@ -1,11 +1,11 @@
 <ul class="livestats">
     <li>
         <span class="title">VM</span>
-        <strong>{!! $vm_running !!}<span>/{!! $vm_total !!}</span></strong>
+        <strong><span>{!! $vm_running !!}/{!! $vm_total !!}</span></strong>
     </li>
     <li>
         <span class="title">LXC</span>
-        <strong>{!! $container_running !!}<span>/{!! $container_total !!}</span></strong>
+        <strong><span>{!! $container_running !!}/{!! $container_total !!}</span></strong>
     </li>
     <li>
         <span class="title">CPU</span>


### PR DESCRIPTION
It groups the numbers together so it looks like '1/1' instead of '1 /1'.
![image](https://user-images.githubusercontent.com/49018201/236729561-91f463bc-d75f-4a1b-a5a5-fd8d5bbf8d29.png)
