### PR TITLE
Jellyseerr count options

### DIFF
--- a/Jellyseerr/Jellyseerr.php
+++ b/Jellyseerr/Jellyseerr.php
@@ -2,70 +2,70 @@
 
 class Jellyseerr extends \App\SupportedApps implements \App\EnhancedApps {
 
-	public $config;
+    public $config;
 
-	//protected $login_first = true; // Uncomment if api requests need to be authed first
-	//protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
+    //protected $login_first = true; // Uncomment if api requests need to be authed first
+    //protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
 
-	function __construct() {
-		//$this->jar = new \GuzzleHttp\Cookie\CookieJar; // Uncomment if cookies need to be set
-	}
+    function __construct() {
+        //$this->jar = new \GuzzleHttp\Cookie\CookieJar; // Uncomment if cookies need to be set
+    }
 
-	public function test()
-	{
-		$attrs = $this->getRequestAttrs();
-		$test = parent::appTest($this->url("auth/me"), $attrs);
+    public function test()
+    {
+        $attrs = $this->getRequestAttrs();
+        $test = parent::appTest($this->url("auth/me"), $attrs);
 
-		echo $test->status;
-	}
+        echo $test->status;
+    }
 
-	public function livestats()
-	{
-		$status = "inactive";
-		$data = [];
-		$attrs = $this->getRequestAttrs();
-		$requestsType = $this->getConfigValue("requests", "pending");
-		$requestsCount = json_decode(
-			parent::execute($this->url("request/count"), $attrs)->getBody()
-		);
-		$issuesType = $this->getConfigValue("issues", "open");
-		$issuesCount = json_decode(
-			parent::execute($this->url("issue/count"), $attrs)->getBody()
-		);
+    public function livestats()
+    {
+        $status = "inactive";
+        $data = [];
+        $attrs = $this->getRequestAttrs();
+        $requestsType = $this->getConfigValue("requests", "pending");
+        $requestsCount = json_decode(
+            parent::execute($this->url("request/count"), $attrs)->getBody()
+        );
+        $issuesType = $this->getConfigValue("issues", "open");
+        $issuesCount = json_decode(
+            parent::execute($this->url("issue/count"), $attrs)->getBody()
+        );
 
-		if ($requestsCount || $issuesCount) 
-		{
-			$data["requests"] = $requestsCount->$requestsType ?? 0;
-			$data["issues"] = $issuesCount->$issuesType ?? 0;
-		}
+        if ($requestsCount || $issuesCount) 
+        {
+            $data["requests"] = $requestsCount->$requestsType ?? 0;
+            $data["issues"] = $issuesCount->$issuesType ?? 0;
+        }
 
-		return parent::getLiveStats($status, $data);
-	}
+        return parent::getLiveStats($status, $data);
+    }
 
-	public function url($endpoint)
-	{
-		$api_url =
-			parent::normaliseurl($this->config->url) .
-			"api/v1/" .
-			$endpoint;
+    public function url($endpoint)
+    {
+        $api_url =
+            parent::normaliseurl($this->config->url) .
+            "api/v1/" .
+            $endpoint;
 
-		return $api_url;
-	}
+        return $api_url;
+    }
 
-	public function getRequestAttrs()
-	{
-		$attrs["headers"] = [
-			"accept" => "application/json",
-			"X-Api-Key" => $this->config->apikey,
-		];
+    public function getRequestAttrs()
+    {
+        $attrs["headers"] = [
+            "accept" => "application/json",
+            "X-Api-Key" => $this->config->apikey,
+        ];
 
-		return $attrs;
-	}
+        return $attrs;
+    }
 
-	public function getConfigValue($key, $default = null)
-	{
-		return isset($this->config) && isset($this->config->$key)
-			? $this->config->$key
-			: $default;
-	}
+    public function getConfigValue($key, $default = null)
+    {
+        return isset($this->config) && isset($this->config->$key)
+            ? $this->config->$key
+            : $default;
+    }
 }

--- a/Jellyseerr/Jellyseerr.php
+++ b/Jellyseerr/Jellyseerr.php
@@ -33,7 +33,7 @@ class Jellyseerr extends \App\SupportedApps implements \App\EnhancedApps {
             parent::execute($this->url("issue/count"), $attrs)->getBody()
         );
 
-        if ($requestsCount || $issuesCount) 
+        if ($requestsCount || $issuesCount)
         {
             $data["requests"] = $requestsCount->$requestsType ?? 0;
             $data["issues"] = $issuesCount->$issuesType ?? 0;

--- a/Jellyseerr/Jellyseerr.php
+++ b/Jellyseerr/Jellyseerr.php
@@ -2,30 +2,30 @@
 
 class Jellyseerr extends \App\SupportedApps implements \App\EnhancedApps {
 
-    public $config;
+	public $config;
 
-    //protected $login_first = true; // Uncomment if api requests need to be authed first
-    //protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
+	//protected $login_first = true; // Uncomment if api requests need to be authed first
+	//protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
 
-    function __construct() {
-        //$this->jar = new \GuzzleHttp\Cookie\CookieJar; // Uncomment if cookies need to be set
-    }
+	function __construct() {
+		//$this->jar = new \GuzzleHttp\Cookie\CookieJar; // Uncomment if cookies need to be set
+	}
 
-    public function test()
-    {
-        $attrs = $this->getRequestAttrs();
+	public function test()
+	{
+		$attrs = $this->getRequestAttrs();
 		$test = parent::appTest($this->url("auth/me"), $attrs);
 
 		echo $test->status;
-    }
+	}
 
-    public function livestats()
-    {
+	public function livestats()
+	{
 		$status = "inactive";
 		$data = [];
 		$attrs = $this->getRequestAttrs();
 		$requestsType = $this->getConfigValue("requests", "pending");
-        $requestsCount = json_decode(
+		$requestsCount = json_decode(
 			parent::execute($this->url("request/count"), $attrs)->getBody()
 		);
 		$issuesType = $this->getConfigValue("issues", "open");
@@ -33,24 +33,24 @@ class Jellyseerr extends \App\SupportedApps implements \App\EnhancedApps {
 			parent::execute($this->url("issue/count"), $attrs)->getBody()
 		);
 
-        if ($requestsCount || $issuesCount) 
-        {
+		if ($requestsCount || $issuesCount) 
+		{
 			$data["requests"] = $requestsCount->$requestsType ?? 0;
 			$data["issues"] = $issuesCount->$issuesType ?? 0;
 		}
 
-        return parent::getLiveStats($status, $data);
-    }
+		return parent::getLiveStats($status, $data);
+	}
 
-    public function url($endpoint)
-    {
-        $api_url =
+	public function url($endpoint)
+	{
+		$api_url =
 			parent::normaliseurl($this->config->url) .
 			"api/v1/" .
 			$endpoint;
 
 		return $api_url;
-    }
+	}
 
 	public function getRequestAttrs()
 	{

--- a/Jellyseerr/config.blade.php
+++ b/Jellyseerr/config.blade.php
@@ -1,5 +1,5 @@
 <h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
-<div class="items">
+<div class="items" style="flex-wrap: wrap;">
     <div class="input">
         <label>{{ strtoupper(__('app.url')) }}</label>
         {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
@@ -10,5 +10,19 @@
     </div>
     <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+    <div class="input">
+        <label>Requests count</label>
+        {!! Form::select('config[requests]', ['pending' => 'Pending', 'approved' => 'Approved', 'declined' => 'Declined', 'processing' => 'Processing', 'available' => 'Available', 'movie' => 'Movie', 'tv' => 'TV', 'total' => 'Total'], isset($item) && isset($item->getconfig()->requests) ? $item->getconfig()->requests : null, [
+            'id' => 'requests',
+            'class' => 'form-control config-item',
+        ]) !!}
+    </div>
+    <div class="input">
+        <label>Issues count</label>
+        {!! Form::select('config[issues]', ['open' => 'Open', 'closed' => 'Closed', 'video' => 'Video', 'audio' => 'Audio', 'subtitles' => 'Subtitles', 'others' => 'Others', 'total' => 'Total'], isset($item) && isset($item->getconfig()->issues) ? $item->getconfig()->issues : null, [
+            'id' => 'issues',
+            'class' => 'form-control config-item',
+        ]) !!}
     </div>
 </div>


### PR DESCRIPTION
Jellyseerr app is setup with counts of **pending** requests and **open** issues by default. My Jellyseerr is setup to auto approve all requests. So my pending requests count will always be 0 with these defaults. Added config options to change default settings for requests and issues counts shown for the Jellyseerr app.

![image](https://github.com/linuxserver/Heimdall-Apps/assets/44654729/7d946462-0449-42e8-9496-0f7a3702d1ed)
![image](https://github.com/linuxserver/Heimdall-Apps/assets/44654729/394db4cb-4c4a-4737-9b93-1aa61a5bd2fb)
