### PR TITLE
Update openmediavault rpc properties for CPU Stats

### DIFF
--- a/openmediavault/openmediavault.php
+++ b/openmediavault/openmediavault.php
@@ -79,7 +79,8 @@ class openmediavault extends \App\SupportedApps implements \App\EnhancedApps
 		$data = ["visiblestats" => []];
 
 		$info = $this->request("system", "getInformation");
-		$data["CPU"] = sprintf("%.1f%%", $info->cpuUsage);
+		$stats = $this->request("system", "getCpuStats");
+		$data["CPU"] = sprintf("%.1f%%", $stats->utilization);
 		$data["RAM"] = sprintf(
 			"%.1f%%",
 			($info->memUsed / $info->memTotal) * 100


### PR DESCRIPTION
As reported in [linuxserver/Heimdall#651](https://github.com/linuxserver/Heimdall-Apps/issues/651), openmediavault moved the CPU stats RPC to a new one: `System::getCpuStats`