### PR TITLE
AVMFritzBox: add override url config to allow reverse proxied linking urls

### DIFF
--- a/AVMFritzbox/config.blade.php
+++ b/AVMFritzbox/config.blade.php
@@ -1,6 +1,10 @@
 <h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
 <div class="items">
     <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
         <label>Stats to show</label>
         {!! Form::select('config[availablestats][]', App\SupportedApps\AVMFritzbox\AVMFritzbox::getAvailableStats(), isset($item) ? $item->getConfig()->availablestats ?? null : null, ['multiple' => 'multiple']) !!}
     </div>


### PR DESCRIPTION
This PR simply adds the default override url config option for the AVM Fritzbox app.

This is needed if the user is running a reverse proxy like NGINX and would like to enter the proxied URL like https://fritzbox.example.com as linking url.
As the URL is used with a custom port for the API queries, these fail when doing so.

To fix this, I enabled the override option for the url.

Now I am able to specify the linking url as https://fritzbox.example.com and the API (override) url as http://10.0.0.1 (or any other IP/domain)