### PR TITLE
Update TrueNASCORE livestats to differentiate between notices/info and alerts that need immediate attention

### DIFF
--- a/TrueNASCORE/TrueNASCORE.php
+++ b/TrueNASCORE/TrueNASCORE.php
@@ -36,7 +36,7 @@ class TrueNASCORE extends \App\SupportedApps implements \App\EnhancedApps
 
 		$res = parent::execute($this->url("alert/list"), $this->attrs());
 		$details = json_decode($res->getBody(), true);
-		$data["alert_tot"] = $this->alerts($details);
+		list($data["alert_tot"], $data["alert_crit"]) = $this->alerts($details);
 
 		return parent::getLiveStats($status, $data);
 	}
@@ -109,14 +109,17 @@ class TrueNASCORE extends \App\SupportedApps implements \App\EnhancedApps
 
 	public function alerts($alert)
 	{
-		$count = 0;
+		$count_total = $count_critical = 0;
 		foreach ($alert as $key => $value) {
 			if ($value["dismissed"] == false) {
-				$count += 1;
+				$count_total += 1;
+				if (!in_array($value["level"], array("NOTICE", "INFO"))) {
+					$count_critical += 1;
+				}	
 			}
 		}
 
-		return strval($count);
+		return array(strval($count_total), strval($count_critical));
 	}
 
 	public function getConfigValue($key, $default = null)

--- a/TrueNASCORE/livestats.blade.php
+++ b/TrueNASCORE/livestats.blade.php
@@ -5,6 +5,6 @@
     </li>
     <li>
         <span class="title">Alerts</span>
-        <strong>{!! $alert_tot !!}</strong>
+        <strong>{!! $alert_tot !!}  / <span style="background-color: #d64d55; padding: 3px; color: white; font-size: 12px; border-radius: 3px; opacity: 1;">{!! $alert_crit !!}</span></strong>
     </li>
 </ul>


### PR DESCRIPTION
Previously, only total amounts of alerts was shown in the livestats. Commits add seperate mention of more critical alerts with a red background.

![image](https://github.com/linuxserver/Heimdall-Apps/assets/22548191/c44a4c16-773e-4379-88aa-2674d3fe7629)
