### PR TITLE
Update workflows and super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,9 @@ name: Lint Code Base
 #############################
 on: # yamllint disable-line rule:truthy
   push:
-    # Remove the line above to run when pushing to master
+    branches:
+      - 'master'
+      - 'releases/**'
   pull_request:
 
 ###############
@@ -54,6 +56,6 @@ jobs:
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v5
         env:
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,11 +6,6 @@
 #################################
 name: Lint Code Base
 
-#
-# Documentation:
-# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
-#
-
 #############################
 # Start the job on all push #
 #############################
@@ -47,7 +42,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
+          # Full git history is needed to get a proper list of changed files
+          # within `super-linter`
           fetch-depth: 0
 
       ################################

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v5
         env:
-          VALIDATE_ALL_CODEBASE: false
-          # Change to 'master' if your main branch differs
-          DEFAULT_BRANCH: main
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,6 +15,7 @@ on: # yamllint disable-line rule:truthy
       - 'master'
       - 'releases/**'
   pull_request:
+    types: [opened, edited, synchronize, reopened, review_requested]
 
 ###############
 # Set the Job #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ name: Lint Code Base
 #############################
 # Start the job on all push #
 #############################
-on:
+on: # yamllint disable-line rule:truthy
   push:
     # Remove the line above to run when pushing to master
   pull_request:
@@ -29,6 +29,12 @@ jobs:
     # Set the agent to run on
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
     ##################
     # Load all steps #
     ##################
@@ -37,7 +43,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -46,7 +52,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: super-linter/super-linter/slim@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           # Change to 'master' if your main branch differs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+---
 name: Deploy to GitHub Pages
 
 on:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node env
         uses: actions/setup-node@v3.6.0

--- a/.github/workflows/prchecks.yml
+++ b/.github/workflows/prchecks.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node env
         uses: actions/setup-node@v3.6.0

--- a/.github/workflows/prchecks.yml
+++ b/.github/workflows/prchecks.yml
@@ -1,3 +1,4 @@
+---
 name: PR Checks
 
 on:

--- a/.github/workflows/svgo.yml
+++ b/.github/workflows/svgo.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Optimize SVGs
         uses: ericcornelissen/svgo-action@v3
         id: svgo

--- a/.github/workflows/svgo.yml
+++ b/.github/workflows/svgo.yml
@@ -1,3 +1,4 @@
+---
 # GitHub Action uses SVGO to Minify and removeDimensions of SVG files
 name: Optimize SVG Files
 
@@ -25,4 +26,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         if: ${{steps.svgo.outputs.DID_OPTIMIZE}}
         with:
-          commit_message: Optimize ${{steps.svgo.outputs.OPTIMIZED_COUNT}} SVG(s)
+          commit_message: Optimize ${{steps.svgo.outputs.OPTIMIZED_COUNT}} SVG(s) # yamllint disable-line rule:line-length


### PR DESCRIPTION
Bump versions of actions and switch to super-lint/super-linter/slim which is much more up-to-date than the github/super-linter fork.