### PR TITLE
feat: enhance scrutiny foundation app

### DIFF
--- a/Scrutiny/Scrutiny.php
+++ b/Scrutiny/Scrutiny.php
@@ -2,6 +2,62 @@
 
 namespace App\SupportedApps\Scrutiny;
 
-class Scrutiny extends \App\SupportedApps
+class Scrutiny extends \App\SupportedApps implements \App\EnhancedApps
 {
+	public $config;
+
+	public function __construct()
+	{
+	}
+
+	public function test()
+	{
+		$attrs = [
+			"headers" => ["Accept" => "application/json"],
+		];
+		$test = parent::appTest($this->url("health"), $attrs);
+		echo $test->status;
+	}
+
+	public function livestats()
+	{
+		$status = "inactive";
+		$data = [
+			"passed" => 0,
+			"failed" => 0,
+		];
+
+		$attrs = [
+			"headers" => ["Accept" => "application/json"],
+		];
+
+		$response = json_decode(
+			parent::execute($this->url("summary"), $attrs)->getBody()
+		);
+
+		$summary = $response->data->summary;
+
+		foreach ($summary as $entry) {
+			$device_status = $entry->device->device_status;
+
+			if ($device_status == 0) {
+				$data["passed"]++;
+			} else {
+				$status = "active";
+				$data["failed"]++;
+			}
+		}
+
+		return parent::getLiveStats($status, $data);
+	}
+
+	public function url($endpoint)
+	{
+		$api_url =
+			parent::normaliseurl($this->config->url) .
+			"api/" .
+			$endpoint;
+
+		return $api_url;
+	}
 }

--- a/Scrutiny/Scrutiny.php
+++ b/Scrutiny/Scrutiny.php
@@ -4,60 +4,60 @@ namespace App\SupportedApps\Scrutiny;
 
 class Scrutiny extends \App\SupportedApps implements \App\EnhancedApps
 {
-	public $config;
+    public $config;
 
-	public function __construct()
-	{
-	}
+    public function __construct()
+    {
+    }
 
-	public function test()
-	{
-		$attrs = [
-			"headers" => ["Accept" => "application/json"],
-		];
-		$test = parent::appTest($this->url("health"), $attrs);
-		echo $test->status;
-	}
+    public function test()
+    {
+        $attrs = [
+            "headers" => ["Accept" => "application/json"],
+        ];
+        $test = parent::appTest($this->url("health"), $attrs);
+        echo $test->status;
+    }
 
-	public function livestats()
-	{
-		$status = "inactive";
-		$data = [
-			"passed" => 0,
-			"failed" => 0,
-		];
+    public function livestats()
+    {
+        $status = "inactive";
+        $data = [
+            "passed" => 0,
+            "failed" => 0,
+        ];
 
-		$attrs = [
-			"headers" => ["Accept" => "application/json"],
-		];
+        $attrs = [
+            "headers" => ["Accept" => "application/json"],
+        ];
 
-		$response = json_decode(
-			parent::execute($this->url("summary"), $attrs)->getBody()
-		);
+        $response = json_decode(
+            parent::execute($this->url("summary"), $attrs)->getBody()
+        );
 
-		$summary = $response->data->summary;
+        $summary = $response->data->summary;
 
-		foreach ($summary as $entry) {
-			$device_status = $entry->device->device_status;
+        foreach ($summary as $entry) {
+            $device_status = $entry->device->device_status;
 
-			if ($device_status == 0) {
-				$data["passed"]++;
-			} else {
-				$status = "active";
-				$data["failed"]++;
-			}
-		}
+            if ($device_status == 0) {
+                $data["passed"]++;
+            } else {
+                $status = "active";
+                $data["failed"]++;
+            }
+        }
 
-		return parent::getLiveStats($status, $data);
-	}
+        return parent::getLiveStats($status, $data);
+    }
 
-	public function url($endpoint)
-	{
-		$api_url =
-			parent::normaliseurl($this->config->url) .
-			"api/" .
-			$endpoint;
+    public function url($endpoint)
+    {
+        $api_url =
+            parent::normaliseurl($this->config->url) .
+            "api/" .
+            $endpoint;
 
-		return $api_url;
-	}
+        return $api_url;
+    }
 }

--- a/Scrutiny/app.json
+++ b/Scrutiny/app.json
@@ -4,7 +4,7 @@
   "website": "https://github.com/AnalogJ/scrutiny",
   "license": "MIT License",
   "description": "Scrutiny is a Hard Drive Health Dashboard & Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates.",
-  "enhanced": false,
+  "enhanced": true,
   "tile_background": "light",
   "icon": "scrutiny.png"
 }

--- a/Scrutiny/config.blade.php
+++ b/Scrutiny/config.blade.php
@@ -1,0 +1,23 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+	<input type="hidden" data-config="dataonly" class="config-item" name="config[dataonly]" value="1" />
+	<div class="input">
+		<label>{{ strtoupper(__('app.url')) }}</label>
+		{!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+	</div>
+	<div class="input">
+		<label>Skip TLS verification</label>
+		<div class="toggleinput" style="margin-top: 26px; padding-left: 15px;">
+			{!! Form::hidden('config[ignore_tls]', 0, ['class' => 'config-item', 'data-config' => 'ignore_tls']) !!}
+		<label class="switch">
+			checked="checked"' : '';
+                ?>
+                <input type="checkbox" class="config-item" data-config="ignore_tls" name="config[ignore_tls]" value="1" <?php echo $set_checked; ?> />
+			<span class="slider round"></span>
+		</label>
+	</div>
+</div>
+<div class="input">
+	<button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+</div>
+</div>

--- a/Scrutiny/livestats.blade.php
+++ b/Scrutiny/livestats.blade.php
@@ -1,0 +1,11 @@
+<ul class="livestats">
+	<li>
+		<span class="title">Passed</span>
+		<strong>{!! $passed ?? 0 !!}</strong>
+	</li>
+
+	<li>
+		<span class="title">Failed</span>
+		<strong>{!! $failed ?? 0 !!}</strong>
+	</li>
+</ul>


### PR DESCRIPTION
enhances the scrutiny app to include the passed & failed drives

I really think that this should be a bit more.. LOUD when there's failed drives but, eh..

If there's more interesting information this should have instead it can be easily pulled.

![Screenshot 2024-02-26 at 00-21-50 Heimdall](https://github.com/linuxserver/Heimdall-Apps/assets/1551593/0eee8c29-1577-489e-8181-688426862347)

Note: I tried to add this as a requested app first but it seems the apps list on the site caps out around the "R"s so I can't actually select scrutiny to request enhanced. 