### PR TITLE
fix: switch jellyfin to use non-deprecated auth mechanism

### DIFF
--- a/Jellyfin/Jellyfin.php
+++ b/Jellyfin/Jellyfin.php
@@ -43,7 +43,7 @@ class Jellyfin extends \App\SupportedApps implements \App\EnhancedApps
     {
         return [
             "headers" => [
-                "X-MediaBrowser-Token" => $this->config->password,
+                "Authorization" => "MediaBrowser Token=\"" . urlencode($this->config->password) . "\"",
             ],
         ];
     }

--- a/Jellyfin/Jellyfin.php
+++ b/Jellyfin/Jellyfin.php
@@ -41,9 +41,12 @@ class Jellyfin extends \App\SupportedApps implements \App\EnhancedApps
 
     private function getAttrs()
     {
+        $authorizationHeader = "MediaBrowser " .
+            "Token=\"" . urlencode($this->config->password) . "\", " .
+            "Client=\"Heimdall\"";
         return [
             "headers" => [
-                "Authorization" => "MediaBrowser Token=\"" . urlencode($this->config->password) . "\"",
+                "Authorization" => $authorizationHeader,
             ],
         ];
     }

--- a/Jellyfin/Jellyfin.php
+++ b/Jellyfin/Jellyfin.php
@@ -13,7 +13,7 @@ class Jellyfin extends \App\SupportedApps implements \App\EnhancedApps
     public function test()
     {
         $test = parent::appTest(
-            $this->url("System/Info/Public"),
+            $this->url("System/Info"),
             $this->getAttrs()
         );
         echo $test->status;


### PR DESCRIPTION
fixes #669

switches the authentication mechanism to be the non-deprecated `Authorization` header

https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f

as part of this, switches the jellyfin connectivity test to use `info` rather than `info/public` because `info/public` ignores all auth

this works against a live jellyfin server using the official jellyfin docker image