### PR TITLE
Add api headers to test

### DIFF
--- a/Immich/Immich.php
+++ b/Immich/Immich.php
@@ -16,7 +16,13 @@ class Immich extends \App\SupportedApps implements \App\EnhancedApps
 
     public function test()
     {
-        $test = parent::appTest($this->url("server-info/statistics"));
+        $attrs = [
+            "headers" => [
+                "Accept" => "application/json",
+                "x-api-key" => $this->config->api_key,
+            ],
+        ];
+        $test = parent::appTest($this->url("server-info/statistics"), $attrs);
         echo $test->status;
     }
 


### PR DESCRIPTION
The API test for Immich always fails as unauthorized because there is no 'x-api-key' header in the test request.

This patch works with Immich v1.107.2