### PR TITLE
Fix *arr url creation

### DIFF
--- a/Bazarr/Bazarr.php
+++ b/Bazarr/Bazarr.php
@@ -48,7 +48,7 @@ class Bazarr extends \App\SupportedApps implements \App\EnhancedApps
     public function url($endpoint)
     {
         $api_url =
-            parent::normaliseurl($this->config->url) .
+            parent::normaliseurl($this->config->url, true) .
             "api/" .
             $endpoint .
             "?apikey=" .

--- a/Lidarr/Lidarr.php
+++ b/Lidarr/Lidarr.php
@@ -39,7 +39,7 @@ class Lidarr extends \App\SupportedApps implements \App\EnhancedApps
     public function url($endpoint)
     {
         $api_url =
-            parent::normaliseurl($this->config->url) .
+            parent::normaliseurl($this->config->url, true) .
             "api/v1/" .
             $endpoint .
             "?apikey=" .

--- a/Prowlarr/Prowlarr.php
+++ b/Prowlarr/Prowlarr.php
@@ -46,7 +46,7 @@ class Prowlarr extends \App\SupportedApps implements \App\EnhancedApps
     public function url($endpoint)
     {
         $api_url =
-            parent::normaliseurl($this->config->url) .
+            parent::normaliseurl($this->config->url, true) .
             "api/v1/" .
             $endpoint .
             "?apikey=" .

--- a/Radarr/Radarr.php
+++ b/Radarr/Radarr.php
@@ -43,7 +43,7 @@ class Radarr extends \App\SupportedApps implements \App\EnhancedApps
     public function url($endpoint)
     {
         $api_url =
-            parent::normaliseurl($this->config->url) .
+            parent::normaliseurl($this->config->url, true) .
             "api/v3/" .
             $endpoint .
             "?apikey=" .

--- a/Readarr/Readarr.php
+++ b/Readarr/Readarr.php
@@ -62,7 +62,7 @@ class Readarr extends \App\SupportedApps implements \App\EnhancedApps
     public function url($endpoint)
     {
         $api_url =
-            parent::normaliseurl($this->config->url) .
+            parent::normaliseurl($this->config->url, true) .
             "api/v1/" .
             $endpoint .
             "apikey=" .

--- a/Sonarr/Sonarr.php
+++ b/Sonarr/Sonarr.php
@@ -51,7 +51,7 @@ class Sonarr extends \App\SupportedApps implements \App\EnhancedApps
     public function url($endpoint)
     {
         $api_url =
-            parent::normaliseurl($this->config->url) .
+            parent::normaliseurl($this->config->url, true) .
             "api/v3/" .
             $endpoint .
             "?sortKey=series.title&apikey=" .


### PR DESCRIPTION
Seems like at some point `normaliseurl` changed or someone edited the `/` off the next line causing all attempts to verify enhanced apps were set up correctly to fail. This should solve that by using the second input of the `normaliseurl` function.