### PR TITLE
Add support for Self Hosted UniFi Controllers

### DIFF
--- a/UniFi/UniFi.php
+++ b/UniFi/UniFi.php
@@ -67,13 +67,14 @@ class UniFi extends \App\SupportedApps
                     // TODO: Update UI to adapt to lack of Switches
                     $data['lan_users'] = isset($detail->num_user) ? $detail->num_user : 0;
                     $data['num_sw'] = isset($detail->num_sw) ? $detail->num_sw : 0;
-
                 }
 
                 if ($detail->subsystem === 'wan') {
                     // Handle lack of GW
                     // TODO: Update UI to adapt to lack of GW
-                    $data['wan_avail'] = isset($detail->uptime_stats->WAN->availability) ? number_format($detail->uptime_stats->WAN->availability, 0) : 0;
+                    $data['wan_avail'] = isset($detail->uptime_stats->WAN->availability)
+                                       ? number_format($detail->uptime_stats->WAN->availability, 0)
+                                       : 0;
                     $data['num_gw'] = isset($detail->num_gw) ? $detail->num_gw : 0;
                 }
             }

--- a/UniFi/UniFi.php
+++ b/UniFi/UniFi.php
@@ -19,8 +19,9 @@ class UniFi extends \App\SupportedApps
 
     public function test()
     {
+        $urls = $this->getAPIURLs();
         $test = parent::appTest(
-            $this->url("/api/auth/login"),
+            $this->url($urls['loginURL']),
             $this->getLoginAttributes(),
         );
 
@@ -30,16 +31,16 @@ class UniFi extends \App\SupportedApps
     public function livestats()
     {
         $status = "inactive";
-
+        $urls = $this->getAPIURLs();
         parent::execute(
-            $this->url("/api/auth/login"),
+            $this->url($urls['loginURL']),
             $this->getLoginAttributes(),
             null,
             'POST'
         );
 
         $res = parent::execute(
-            $this->url("/proxy/network/api/s/default/stat/health"),
+            $this->url($urls['statsURL']),
             $this->getAttributes(),
             null,
             'GET'
@@ -53,17 +54,27 @@ class UniFi extends \App\SupportedApps
             $data['error'] = false;
             foreach ($details->data as $key => $detail) {
                 if ($detail->subsystem === 'wlan') {
-                    $data['wlan_users'] = $detail->num_user;
-                    $data['wlan_ap'] = $detail->num_ap;
-                    $data['wlan_dc'] = $detail->num_disconnected;
+                    // Handle lack of APs
+                    // TODO: Update UI to adapt to lack of APs
+                    $data['wlan_users'] = isset($detail->num_user) ? $detail->num_user : 0;
+                    $data['wlan_ap'] = isset($detail->num_ap) ? $detail->num_ap : 0;
+                    $data['wlan_dc'] = isset($detail->num_disconnected) ? $detail->num_disconnected : 0;
+                    $data['num_ap'] = isset($detail->num_ap) ? $detail->num_ap : 0;
                 }
 
                 if ($detail->subsystem === 'lan') {
-                    $data['lan_users'] = $detail->num_user;
+                    // Handle lack of Switches
+                    // TODO: Update UI to adapt to lack of Switches
+                    $data['lan_users'] = isset($detail->num_user) ? $detail->num_user : 0;
+                    $data['num_sw'] = isset($detail->num_sw) ? $detail->num_sw : 0;
+
                 }
 
                 if ($detail->subsystem === 'wan') {
-                    $data['wan_avail'] = number_format($detail->uptime_stats->WAN->availability, 0);
+                    // Handle lack of GW
+                    // TODO: Update UI to adapt to lack of GW
+                    $data['wan_avail'] = isset($detail->uptime_stats->WAN->availability) ? number_format($detail->uptime_stats->WAN->availability, 0) : 0;
+                    $data['num_gw'] = isset($detail->num_gw) ? $detail->num_gw : 0;
                 }
             }
         } else {
@@ -137,5 +148,22 @@ class UniFi extends \App\SupportedApps
         }
 
         return $attrs;
+    }
+
+    public function getAPIURLs() {
+        $self_hosted = $this->getConfigValue("self_hosted", false);
+        // Default to UDM URLs
+        $urls = [
+            "loginURL" => "/api/auth/login",
+            "statsURL" => "/proxy/network/api/s/default/stat/health",
+        ];
+        if ($self_hosted) {
+            // Self hosted URLs
+            $urls = [
+                "loginURL" => "/api/login",
+                "statsURL" => "/api/s/default/stat/health",
+            ];
+        }
+        return $urls;
     }
 }

--- a/UniFi/config.blade.php
+++ b/UniFi/config.blade.php
@@ -31,6 +31,23 @@
         </div>
     </div>
     <div class="input">
+        <label>Self Hosted</label>
+        <div class="toggleinput" style="margin-top: 26px; padding-left: 15px;">
+            {!! Form::hidden('config[self_hosted]', 0, ['class' => 'config-item', 'data-config' => 'self_hosted']) !!}
+            <label class="switch">
+                <?php
+                $checked_selfhost = false;
+                if (isset($item) && !empty($item) && isset($item->getconfig()->self_hosted)) {
+                    $checked_selfhost = $item->getconfig()->self_hosted;
+                }
+                $set_checked_selfhost = $checked_selfhost ? ' checked="checked"' : '';
+                ?>
+                <input type="checkbox" class="config-item" data-config="self_hosted" name="config[self_hosted]" value="1" <?php echo $set_checked_selfhost; ?> />
+                <span class="slider round"></span>
+            </label>
+        </div>
+    </div>
+    <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
     </div>
 </div>


### PR DESCRIPTION
This PR adds a "Self Hosted" switch to the config blade and uses the correct API URLs based on this switch. When the switch is enabled it uses the legacy URLs for Self Hosted controllers, when disabled (default) it uses the API URLs for the UDM hosted controller.