### PR TITLE
Diaspora Enhanced App - Remove external api dependency

### DIFF
--- a/Diaspora/app.json
+++ b/Diaspora/app.json
@@ -3,7 +3,7 @@
     "name": "Diaspora",
     "website": "https://diasporafoundation.org/",
     "license": "GNU Affero General Public License v3.0 only",
-    "description": "A privacy-aware, distributed, open source social network. Limitation: diaspora pod must be available at https://fediverse.observer/!",
+    "description": "A privacy-aware, distributed, open source social network",
     "enhanced": true,
     "tile_background": "light",
     "icon": "diaspora.svg"


### PR DESCRIPTION
This integration no longer requires the external api and instead uses the local nodeInfo found at `https://diasporaURL/nodeinfo/2.1`. This pull requests also removes no longer relevant functions and available stats.