### PR TITLE
Improve error handling in Pihole app

### DIFF
--- a/Pihole/Pihole.php
+++ b/Pihole/Pihole.php
@@ -115,7 +115,6 @@ class Pihole extends \App\SupportedApps implements \App\EnhancedApps
         $auth = json_decode($response->getBody());
 
         if (!$auth->session->valid) {
-
             $data = [
                 'valid'    => false,
                 'validity' => -1,
@@ -123,7 +122,6 @@ class Pihole extends \App\SupportedApps implements \App\EnhancedApps
                 'queries'  => 0,
                 'percent'  => 0
             ];
-
             return $data;
         }
 

--- a/Pihole/config.blade.php
+++ b/Pihole/config.blade.php
@@ -2,7 +2,7 @@
 <div class="items">
 	<input type="hidden" data-config="dataonly" class="config-item" name="config[dataonly]" value="1" />
 	<div class="input">
-		<label>{{ strtoupper(__('app.url')) }} (for v6 use https)</label>
+		<label>{{ strtoupper(__('app.url')) }}</label>
 		{!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
 	</div>
 	<div class="input">


### PR DESCRIPTION
When using the wrong password for the API, the app fails to parse the response and just fails with the generic error message "Server error". This made it very hard for me to pinpoint the problem, because if the URL is invalid for example you will get an identical response.

So I improved the error handling when communicating with the API, and now it communicates the correct error message back to the user, for example "invalid password".