### PR TITLE
fix: UptimeKuma Up/Down counts are always zero

### DIFF
--- a/UptimeKuma/UptimeKuma.php
+++ b/UptimeKuma/UptimeKuma.php
@@ -62,7 +62,7 @@ class UptimeKuma extends \App\SupportedApps implements \App\EnhancedApps
                 continue;
             }
 
-            if (strpos($line, 'monitor_status') !== 0) {
+            if (strpos($line, 'monitor_status') === 0) {
                 // If the line is a metric but not a monitor we can ignore it
                 continue;
             }


### PR DESCRIPTION
The Uptime Kuma enhanced application displays its monitors Up/Down live counts.

However, an UptimeKuma/UptimeKuma.php typo in its livestats() function is failing.

Thus its Up and Down counts are always zero.

This PR fixes this issue by using the correct operator: change an !== operator to the === operator.