### PR TITLE
Update UptimeKuma.php

### DIFF
--- a/UptimeKuma/UptimeKuma.php
+++ b/UptimeKuma/UptimeKuma.php
@@ -57,12 +57,12 @@ class UptimeKuma extends \App\SupportedApps implements \App\EnhancedApps
         ];
 
         foreach ($lines as $line) {
-            if (strlen($line) === 0 || strpos($line, '#') === 0) {
+            if (strlen($line) === 0 || strpos($line, '#') !== 0) {
                 // If the line is empty or is a comment we can skip it
                 continue;
             }
 
-            if (strpos($line, 'monitor_status') === 0) {
+            if (strpos($line, 'monitor_status') !== 0) {
                 // If the line is a metric but not a monitor we can ignore it
                 continue;
             }


### PR DESCRIPTION
The previous fix [#824](https://github.com/linuxserver/Heimdall-Apps/pull/824) was a faulty request.

Because correctly only the "monitor status" rows should be counted and the other rows should be ignored.

change an === operator to the !== operator.

sample call:
![image](https://github.com/user-attachments/assets/f7dd0d09-9579-4a3e-9a13-8d924f4276fd)



