### PR TITLE
Update UptimeKuma.php

### DIFF
--- a/UptimeKuma/UptimeKuma.php
+++ b/UptimeKuma/UptimeKuma.php
@@ -62,7 +62,7 @@ class UptimeKuma extends \App\SupportedApps implements \App\EnhancedApps
                 continue;
             }
 
-            if (strpos($line, 'monitor_status') === 0) {
+            if (strpos($line, 'monitor_status') !== 0) {
                 // If the line is a metric but not a monitor we can ignore it
                 continue;
             }


### PR DESCRIPTION
The previous fix https://github.com/linuxserver/Heimdall-Apps/pull/824 was a faulty request.

Because correctly only the "monitor status" rows should be counted and the other rows should be ignored.
change an === operator to the !== operator.

It is possible that the previous patch submitter used an older version or did not reach the server and therefore counted zero.

sample call:
![image](https://github.com/user-attachments/assets/daeaa661-b4ce-4a09-8f3e-9dae8ca31f6c)
