### PR TITLE
Immich: display large numbers with suffixes

### DIFF
--- a/Immich/Immich.php
+++ b/Immich/Immich.php
@@ -26,6 +26,18 @@ class Immich extends \App\SupportedApps implements \App\EnhancedApps
         echo $test->status;
     }
 
+    private function number_format_large($number)
+    {
+        $suffixes = [ "", "k", "M", "G" ];
+        $rank = 0;
+        while (abs($number) > 1000 && $rank < count($suffixes)) {
+            $number /= 1000;
+            $rank++;
+        }
+        $decimals = $number < 10 && $rank > 0 ? 1 : 0;
+        return number_format($number, $decimals) . $suffixes[$rank];
+    }
+
     public function livestats()
     {
         $status = "inactive";
@@ -42,8 +54,8 @@ class Immich extends \App\SupportedApps implements \App\EnhancedApps
 
         if ($details) {
             $status = "active";
-            $data["photos"] = number_format($details->photos);
-            $data["videos"] = number_format($details->videos);
+            $data["photos"] = $this->number_format_large($details->photos);
+            $data["videos"] = $this->number_format_large($details->videos);
             $usageInGiB = number_format($details->usage / 1073741824, 2);
             $data["usage"] = $usageInGiB . 'GiB';
         }

--- a/Immich/Immich.php
+++ b/Immich/Immich.php
@@ -26,7 +26,7 @@ class Immich extends \App\SupportedApps implements \App\EnhancedApps
         echo $test->status;
     }
 
-    private function number_format_large($number)
+    private function formatLargeNumber($number)
     {
         $suffixes = [ "", "k", "M", "G" ];
         $rank = 0;
@@ -54,8 +54,8 @@ class Immich extends \App\SupportedApps implements \App\EnhancedApps
 
         if ($details) {
             $status = "active";
-            $data["photos"] = $this->number_format_large($details->photos);
-            $data["videos"] = $this->number_format_large($details->videos);
+            $data["photos"] = $this->formatLargeNumber($details->photos);
+            $data["videos"] = $this->formatLargeNumber($details->videos);
             $usageInGiB = number_format($details->usage / 1073741824, 2);
             $data["usage"] = $usageInGiB . 'GiB';
         }


### PR DESCRIPTION
Because an app plate is quite small, displaying large numbers can be problematic as they collide and cannot be distinguished.

This commit fixes this issue by displaying large numbers using fewer characters and ISO suffixes, up to G (giga, 10^9).

Here is an example of the problematic behaviour:
<pre>
+-----------------------+
| PHOTOS  VIDEOS  USAGE |
|   14698443 0.94GiB    |
+-----------------------+
</pre>
The 14,698 photo count collides with the 443 video count.

This commit changes the display to:
<pre>
+-----------------------+
| PHOTOS  VIDEOS  USAGE |
|   15k    443  0.94GiB |
+-----------------------+
</pre>