### PR TITLE
Immich: Fix blade's coliding titles

### DIFF
--- a/Immich/livestats.blade.php
+++ b/Immich/livestats.blade.php
@@ -1,10 +1,10 @@
 <ul class="livestats">
     <li>
-        <span class="title">Photos</span>
+        <span class="title">Pics</span>
         <strong>{!! $photos !!}</strong>
     </li>
     <li>
-        <span class="title">Videos</span>
+        <span class="title">Vids</span>
         <strong>{!! $videos !!}</strong>
     </li>
     <li>


### PR DESCRIPTION
Immich blades displays three metrics: one for the number of photos, one for the number of videos and one for the total space usage of its server.

This commit fixes an issue where the titles of those metrics are colliding into a single word: "PHOTOSVIDEOSUSAGE", which impair readability.

Before this commit, the blade reads:
<pre>
+-------------------+
| PHOTOSVIDEOSUSAGE |
|   265 443 0.94GiB |
+-------------------+
</pre>

After this commit, the blade reads:
<pre>
+-------------------+
| PICS  VIDS  USAGE |
|  265  443 0.94GiB |
+-------------------+
</pre>