### PR TITLE
removed span tags from values

### DIFF
--- a/Proxmox/livestats.blade.php
+++ b/Proxmox/livestats.blade.php
@@ -1,11 +1,11 @@
 <ul class="livestats">
     <li>
         <span class="title">VM</span>
-        <strong><span>{!! $vm_running !!}/{!! $vm_total !!}</span></strong>
+        <strong>{!! $vm_running !!}/{!! $vm_total !!}</strong>
     </li>
     <li>
         <span class="title">LXC</span>
-        <strong><span>{!! $container_running !!}/{!! $container_total !!}</span></strong>
+        <strong>{!! $container_running !!}/{!! $container_total !!}</strong>
     </li>
     <li>
         <span class="title">CPU</span>


### PR DESCRIPTION
numbers of total and running containers and VMs are displayed nicer when using a dark background.  I don't see any benefit of using the span tags on values.