### PR TITLE
Fix FreshRSS livestats styling to match other apps

### DIFF
--- a/FreshRSS/livestats.blade.php
+++ b/FreshRSS/livestats.blade.php
@@ -1,7 +1,8 @@
 <ul class="livestats">
     @if ($unread > 0)
         <li>
-            <span class="title" style="color:orange;">{!! $unread !!} Unread</span>
+            <span class="title">Unread</span>
+            <strong>{!! $unread !!}</strong>
         </li>
     @endif
 </ul>


### PR DESCRIPTION
## Summary

The FreshRSS `livestats.blade.php` template used a non-standard structure that didn't match other apps like Miniflux, Sonarr, and Plex.

**Before:**
```blade
<span class="title" style="color:orange;">{!! $unread !!} Unread</span>
```

**After:**
```blade
<span class="title">Unread</span>
<strong>{!! $unread !!}</strong>
```

This aligns with the standard pattern used throughout other apps in this repository.

Fixes linuxserver/Heimdall#1525