### PR TITLE
Fix typo in InfCloud description

### DIFF
--- a/InfCloud/app.json
+++ b/InfCloud/app.json
@@ -3,7 +3,7 @@
     "name": "InfCloud",
     "website": "https://inf-it.com/open-source/clients/infcloud/",
     "license": "GNU Affero General Public License v3.0",
-    "description": "InfCloud ia an open source CalDAV/CardDAV web client implementation",
+    "description": "InfCloud is an open source CalDAV/CardDAV web client implementation.",
     "enhanced": false,
     "tile_background": "dark",
     "icon": "infcloud_logo.svg"


### PR DESCRIPTION
Noticed this when I got a notification that my original InfCloud PR had been merged. Oops!