### PR TITLE
Fix Komga enhanced app live stats

### DIFF
--- a/Komga/Komga.php
+++ b/Komga/Komga.php
@@ -6,32 +6,80 @@ class Komga extends \App\SupportedApps implements \App\EnhancedApps
 {
     public $config;
 
-    //protected $login_first = true; // Uncomment if api requests need to be authed first
-    //protected $method = 'POST';  // Uncomment if requests to the API should be set by POST
-
     public function __construct()
     {
         //$this->jar = new \GuzzleHttp\Cookie\CookieJar; // Uncomment if cookies need to be set
     }
 
+    public function getHeaders()
+    {
+        $username = $this->config->username;
+        $password = $this->config->password;
+
+        $attrs["headers"] = [
+            "Authorization" =>
+                "Basic " . base64_encode($username . ":" . $password),
+            "Accept" => "application/json",
+        ];
+        return $attrs;
+    }
+
     public function test()
     {
-        $test = parent::appTest($this->url("status"));
+        $test = parent::appTest(
+            $this->url("api/v2/users/me"),
+            $this->getHeaders()
+        );
         echo $test->status;
     }
 
     public function livestats()
     {
         $status = "inactive";
-        $res = parent::execute($this->url("status"));
-        $details = json_decode($res->getBody());
+        $data = ["visiblestats" => []];
 
-        $data = [];
+        $stats = $this->config->availablestats ?? ["series", "books"];
+
+        foreach ($stats as $stat) {
+            if (!isset(self::getAvailableStats()[$stat])) {
+                continue;
+            }
+
+            $res = parent::execute(
+                $this->url("api/v1/" . $stat . "?size=1"),
+                $this->getHeaders()
+            );
+
+            $details = $res ? json_decode($res->getBody()) : null;
+
+            if (!isset($details->totalElements)) {
+                continue;
+            }
+
+            $status = "active";
+
+            $newstat = new \stdClass();
+            $newstat->title = self::getAvailableStats()[$stat];
+            $newstat->value = number_format($details->totalElements);
+
+            $data["visiblestats"][] = $newstat;
+        }
+
         return parent::getLiveStats($status, $data);
     }
+
     public function url($endpoint)
     {
         $api_url = parent::normaliseurl($this->config->url) . $endpoint;
         return $api_url;
+    }
+
+    public static function getAvailableStats()
+    {
+        return [
+            "series" => "Series",
+            "books" => "Books",
+            "collections" => "Collections",
+        ];
     }
 }

--- a/Komga/config.blade.php
+++ b/Komga/config.blade.php
@@ -13,6 +13,10 @@
         {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
+        <label>Stats to show</label>
+        {!! Form::select('config[availablestats][]', App\SupportedApps\Komga\Komga::getAvailableStats(), isset($item) ? $item->getConfig()->availablestats ?? null : null, ['multiple' => 'multiple']) !!}
+    </div>
+    <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
     </div>
 </div>

--- a/Komga/livestats.blade.php
+++ b/Komga/livestats.blade.php
@@ -1,10 +1,8 @@
 <ul class="livestats">
-    <li>
-        <span class="title">Queue</span>
-        <strong>{!! $queue_size !!}</strong>
-    </li>
-    <li>
-        <span class="title">Speed</span>
-        <strong>{!! $current_speed !!}</strong>
-    </li>
+    @foreach ($visiblestats as $stat)
+        <li>
+            <span class="title">{!! $stat->title !!}</span>
+            <strong>{!! $stat->value !!}</strong>
+        </li>
+    @endforeach
 </ul>


### PR DESCRIPTION
## Description

Fixes #948 — the Komga enhanced app never displayed stats.

The app was an unfinished scaffold:
- `livestats()` queried a nonexistent `status` endpoint and returned an empty `$data` array
- `livestats.blade.php` referenced `$queue_size` / `$current_speed` (copy-pasted from a downloader app), which caused a 500 on every stats refresh
- The username/password collected by the config form were never sent with API requests

## Changes

- API requests now authenticate with HTTP Basic auth using the configured credentials
- The config **Test** button checks connectivity against `api/v2/users/me`
- Live stats show Series / Books / Collections counts from the paginated v1 API `totalElements`, selectable via a new "Stats to show" multi-select in the config panel (defaults to Series + Books), following the Nextcloud app's pattern