### PR TITLE
openmediavault: add Skip TLS verification option

### DIFF
--- a/openmediavault/config.blade.php
+++ b/openmediavault/config.blade.php
@@ -1,5 +1,5 @@
 <h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
-<div class="items">
+<div class="items" style="flex-wrap: wrap;">
     <div class="input">
         <label>{{ strtoupper(__('app.url')) }}</label>
         {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
@@ -11,6 +11,23 @@
     <div class="input">
         <label>{{ __('app.apps.password') }}</label>
         {!! Form::input('password', 'config[password]', '', ['placeholder' => __('app.apps.password'), 'data-config' => 'password', 'class' => 'form-control config-item']) !!}
+    </div>
+    <div class="input">
+        <label>Skip TLS verification</label>
+        <div class="toggleinput" style="margin-top: 26px; padding-left: 15px;">
+            {!! Form::hidden('config[ignore_tls]', 0, ['class' => 'config-item', 'data-config' => 'ignore_tls']) !!}
+            <label class="switch">
+                <?php
+                $checked = false;
+                if (isset($item) && !empty($item) && isset($item->getconfig()->ignore_tls)) {
+                    $checked = $item->getconfig()->ignore_tls;
+                }
+                $set_checked = $checked ? ' checked="checked"' : '';
+                ?>
+                <input type="checkbox" class="config-item" data-config="ignore_tls" name="config[ignore_tls]" value="1" <?php echo $set_checked; ?> />
+                <span class="slider round"></span>
+            </label>
+        </div>
     </div>
     <div class="input">
         <label>Stats to show</label>

--- a/openmediavault/openmediavault.php
+++ b/openmediavault/openmediavault.php
@@ -33,6 +33,10 @@ class openmediavault extends \App\SupportedApps implements \App\EnhancedApps // 
             "cookies" => $this->cookie,
         ];
 
+        if ($this->getConfigValue("ignore_tls", false)) {
+            $attrs["verify"] = false;
+        }
+
         // @see \App\SupportedApps\execute($url, $attrs = [], $overridevars=false, $overridemethod=false)
         $result = parent::execute($this->url(false), $attrs, null, "POST");
         if (null === $result) {


### PR DESCRIPTION
OMV instances behind self-signed certificates fail every RPC request, which made the enhanced app unusable there — reported in linuxserver/Heimdall#1114, where a fork fix was posted but never landed (and had the verify logic inverted plus a blade parse error).

This ports the repo's established `ignore_tls` pattern (as used by Proxmox, Portainer, TrueNASCORE/SCALE, CraftyController): a "Skip TLS verification" toggle in the app config that sets Guzzle's `verify => false` on the RPC requests when enabled. Verification stays on by default.