### PR TITLE
openmediavault: define getConfigValue helper

### DIFF
--- a/openmediavault/openmediavault.php
+++ b/openmediavault/openmediavault.php
@@ -16,6 +16,13 @@ class openmediavault extends \App\SupportedApps implements \App\EnhancedApps // 
         $this->cookie = new \GuzzleHttp\Cookie\CookieJar();
     }
 
+    public function getConfigValue($key, $default = null)
+    {
+        return isset($this->config) && isset($this->config->$key)
+            ? $this->config->$key
+            : $default;
+    }
+
     public function url($endpoint)
     {
         $api_url = parent::normaliseurl($this->config->url) . "rpc.php";


### PR DESCRIPTION
Follow-up to #977: `getConfigValue` is not defined on the base `SupportedApps` class — apps that use it (Proxmox, Portainer, TrueNAS, ...) each define their own copy. Without this, every openmediavault request fatals with an undefined-method error. Adds the same helper used by the other apps.