### PR TITLE
Dockhand: add enhanced support (running/stopped containers)

### DIFF
--- a/Dockhand/Dockhand.php
+++ b/Dockhand/Dockhand.php
@@ -2,6 +2,108 @@
 
 namespace App\SupportedApps\Dockhand;
 
-class Dockhand extends \App\SupportedApps
+class Dockhand extends \App\SupportedApps implements \App\EnhancedApps
 {
+    public $config;
+
+    public function test()
+    {
+        $test = parent::appTest($this->url("api/environments"), $this->attrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = "inactive";
+        $running = 0;
+        $stopped = 0;
+
+        foreach ($this->environmentIds() as $envId) {
+            $result = parent::execute(
+                $this->url("api/containers?env=" . urlencode($envId)),
+                $this->attrs()
+            );
+            if (null === $result) {
+                continue;
+            }
+            $containers = json_decode($result->getBody());
+            if (!is_array($containers)) {
+                continue;
+            }
+            $status = "active";
+            foreach ($containers as $container) {
+                if (($container->state ?? "") === "running") {
+                    $running++;
+                } else {
+                    $stopped++;
+                }
+            }
+        }
+
+        $data = [
+            "running" => $running,
+            "stopped" => $stopped,
+        ];
+
+        return parent::getLiveStats($status, $data);
+    }
+
+    private function environmentIds()
+    {
+        $configured = trim((string) $this->getConfigValue("environments", ""));
+        if ($configured !== "") {
+            return array_filter(array_map("trim", explode(",", $configured)));
+        }
+
+        $result = parent::execute($this->url("api/environments"), $this->attrs());
+        if (null === $result) {
+            return [];
+        }
+        $environments = json_decode($result->getBody());
+        if (!is_array($environments)) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($environments as $environment) {
+            if (isset($environment->id)) {
+                $ids[] = $environment->id;
+            }
+        }
+        return $ids;
+    }
+
+    public function url($endpoint)
+    {
+        return parent::normaliseurl($this->config->url) . $endpoint;
+    }
+
+    public function attrs()
+    {
+        $attrs = [
+            "headers" => [
+                "Accept" => "application/json",
+            ],
+        ];
+
+        // Dockhand instances with authentication disabled accept
+        // unauthenticated API requests, so the token is optional.
+        $token = $this->getConfigValue("token", null);
+        if (!empty($token)) {
+            $attrs["headers"]["Authorization"] = "Bearer " . $token;
+        }
+
+        if ($this->getConfigValue("ignore_tls", false)) {
+            $attrs["verify"] = false;
+        }
+
+        return $attrs;
+    }
+
+    public function getConfigValue($key, $default = null)
+    {
+        return isset($this->config) && isset($this->config->$key)
+            ? $this->config->$key
+            : $default;
+    }
 }

--- a/Dockhand/app.json
+++ b/Dockhand/app.json
@@ -4,7 +4,7 @@
     "website": "https://dockhand.pro",
     "license": "Apache License 2.0",
     "description": "Modern Docker management for everyone. Licensed under BSL 1.1 The code is naked. Deal with it. Converts to Apache 2.0 in 2029",
-    "enhanced": false,
+    "enhanced": true,
     "tile_background": "light",
     "icon": "dockhand.png"
 }

--- a/Dockhand/config.blade.php
+++ b/Dockhand/config.blade.php
@@ -1,0 +1,37 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items" style="flex-wrap: wrap;">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <label>API Token</label>
+        {!! Form::input('password', 'config[token]', isset($item) ? $item->getconfig()->token : null, ['placeholder' => 'dh_...', 'data-config' => 'token', 'class' => 'form-control config-item']) !!}
+        <p style="font-size: .8em;">Create one in Dockhand under Settings &rarr; API Tokens. Leave empty if authentication is disabled on your instance.</p>
+    </div>
+    <div class="input">
+        <label>Environment IDs</label>
+        {!! Form::text('config[environments]', isset($item) ? $item->getconfig()->environments : null, ['placeholder' => 'Leave blank for all environments', 'data-config' => 'environments', 'class' => 'form-control config-item']) !!}
+        <p style="font-size: .8em;">Comma separated list of environment IDs to count containers for.</p>
+    </div>
+    <div class="input">
+        <label>Skip TLS verification</label>
+        <div class="toggleinput" style="margin-top: 26px; padding-left: 15px;">
+            {!! Form::hidden('config[ignore_tls]', 0, ['class' => 'config-item', 'data-config' => 'ignore_tls']) !!}
+            <label class="switch">
+                <?php
+                $checked = false;
+                if (isset($item) && !empty($item) && isset($item->getconfig()->ignore_tls)) {
+                    $checked = $item->getconfig()->ignore_tls;
+                }
+                $set_checked = $checked ? ' checked="checked"' : '';
+                ?>
+                <input type="checkbox" class="config-item" data-config="ignore_tls" name="config[ignore_tls]" value="1" <?php echo $set_checked; ?> />
+                <span class="slider round"></span>
+            </label>
+        </div>
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+</div>

--- a/Dockhand/livestats.blade.php
+++ b/Dockhand/livestats.blade.php
@@ -1,0 +1,10 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Running</span>
+        <strong>{!! $running !!}</strong>
+    </li>
+    <li>
+        <span class="title">Stopped</span>
+        <strong>{!! $stopped !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
Implements linuxserver/Heimdall#1584 — Portainer-style live stats for the Dockhand tile.

Verified against the Dockhand source (Finsys/dockhand):
- `GET /api/environments` returns the environment list (objects with `id`)
- `GET /api/containers?env=<id>` returns containers with a `state` field (`all` defaults to true, so stopped containers are included)
- API tokens (`dh_` prefix) are accepted as `Authorization: Bearer` — created in Settings → API Tokens; instances with auth disabled accept unauthenticated requests, so the token field is optional

The tile shows Running / Stopped summed across all environments, or a comma-separated list of environment IDs if configured. Includes the repo's standard Skip TLS verification toggle.

Not tested against a live instance — the requester on the issue offered to test, so I'll ask them once this ships.