### PR TITLE
Tracearr: add enhanced support (streams/transcodes/bandwidth)

### DIFF
--- a/Tracearr/Tracearr.php
+++ b/Tracearr/Tracearr.php
@@ -44,11 +44,17 @@ class Tracearr extends \App\SupportedApps implements \App\EnhancedApps
 
     private function getAttrs()
     {
-        return [
+        $attrs = [
             "headers" => [
                 "Accept" => "application/json",
                 "Authorization" => "Bearer " . $this->config->apikey,
             ],
         ];
+
+        if (!empty($this->config->ignore_tls)) {
+            $attrs["verify"] = false;
+        }
+
+        return $attrs;
     }
 }

--- a/Tracearr/Tracearr.php
+++ b/Tracearr/Tracearr.php
@@ -2,6 +2,52 @@
 
 namespace App\SupportedApps\Tracearr;
 
-class Tracearr extends \App\SupportedApps
+class Tracearr extends \App\SupportedApps implements \App\EnhancedApps
 {
+    public $config;
+
+    public function test()
+    {
+        $test = parent::appTest($this->url("api/v2/public/streams?summary=true"), $this->getAttrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = "inactive";
+        $data = [];
+
+        $res = parent::execute($this->url("api/v2/public/streams?summary=true"), $this->getAttrs());
+        $details = json_decode($res->getBody());
+        $summary = $details->summary ?? null;
+
+        if ($summary) {
+            $data = [
+                "streams" => $summary->total,
+                "transcodes" => $summary->transcodes,
+                "bandwidth" => $summary->total_bitrate,
+            ];
+            if ($summary->total > 0) {
+                $status = "active";
+            }
+        }
+
+        return parent::getLiveStats($status, $data);
+    }
+
+    public function url($endpoint)
+    {
+        $api_url = parent::normaliseurl($this->config->url) . $endpoint;
+        return $api_url;
+    }
+
+    private function getAttrs()
+    {
+        return [
+            "headers" => [
+                "Accept" => "application/json",
+                "Authorization" => "Bearer " . $this->config->apikey,
+            ],
+        ];
+    }
 }

--- a/Tracearr/Tracearr.php
+++ b/Tracearr/Tracearr.php
@@ -15,18 +15,19 @@ class Tracearr extends \App\SupportedApps implements \App\EnhancedApps
     public function livestats()
     {
         $status = "inactive";
-        $data = [];
+        $data = [
+            "streams" => 0,
+            "transcodes" => 0,
+            "bandwidth" => "0 Mbps",
+        ];
 
         $res = parent::execute($this->url("api/v2/public/streams?summary=true"), $this->getAttrs());
-        $details = json_decode($res->getBody());
-        $summary = $details->summary ?? null;
+        $summary = $res ? (json_decode($res->getBody())->summary ?? null) : null;
 
         if ($summary) {
-            $data = [
-                "streams" => $summary->total,
-                "transcodes" => $summary->transcodes,
-                "bandwidth" => $summary->total_bitrate,
-            ];
+            $data["streams"] = $summary->total;
+            $data["transcodes"] = $summary->transcodes;
+            $data["bandwidth"] = $summary->total_bitrate;
             if ($summary->total > 0) {
                 $status = "active";
             }

--- a/Tracearr/app.json
+++ b/Tracearr/app.json
@@ -4,7 +4,7 @@
   "website": "https://tracearr.com",
   "license": "Other",
   "description": "Real-time monitoring for Plex, Jellyfin, and Emby servers. Track streams, analyze playback, and detect account sharing from a single dashboard.",
-  "enhanced": false,
+  "enhanced": true,
   "tile_background": "dark",
   "icon": "tracearr.png"
 }

--- a/Tracearr/config.blade.php
+++ b/Tracearr/config.blade.php
@@ -1,0 +1,14 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.apikey') }}</label>
+        {!! Form::text('config[apikey]', isset($item) ? $item->getconfig()->apikey : null, ['placeholder' => __('app.apps.apikey'), 'data-config' => 'apikey', 'class' => 'form-control config-item']) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+</div>

--- a/Tracearr/config.blade.php
+++ b/Tracearr/config.blade.php
@@ -9,6 +9,23 @@
         {!! Form::text('config[apikey]', isset($item) ? $item->getconfig()->apikey : null, ['placeholder' => __('app.apps.apikey'), 'data-config' => 'apikey', 'class' => 'form-control config-item']) !!}
     </div>
     <div class="input">
+        <label>Skip TLS verification</label>
+        <div class="toggleinput" style="margin-top: 26px; padding-left: 15px;">
+            {!! Form::hidden('config[ignore_tls]', 0, ['class' => 'config-item', 'data-config' => 'ignore_tls']) !!}
+            <label class="switch">
+                <?php
+                $checked = false;
+                if (isset($item) && !empty($item) && isset($item->getconfig()->ignore_tls)) {
+                    $checked = $item->getconfig()->ignore_tls;
+                }
+                $set_checked = $checked ? ' checked="checked"' : '';
+                ?>
+                <input type="checkbox" class="config-item" data-config="ignore_tls" name="config[ignore_tls]" value="1" <?php echo $set_checked; ?> />
+                <span class="slider round"></span>
+            </label>
+        </div>
+    </div>
+    <div class="input">
         <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
     </div>
 </div>

--- a/Tracearr/livestats.blade.php
+++ b/Tracearr/livestats.blade.php
@@ -1,0 +1,14 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Streams</span>
+        <strong>{!! $streams !!}</strong>
+    </li>
+    <li>
+        <span class="title">Transcodes</span>
+        <strong>{!! $transcodes !!}</strong>
+    </li>
+    <li>
+        <span class="title">Bandwidth</span>
+        <strong>{!! $bandwidth !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
Follow-up to #974, which added Tracearr as a foundation app.

Verified against the Tracearr source (connorgallopo/Tracearr):
- `GET /api/v2/public/streams?summary=true` returns `{ summary: { total, transcodes, direct_streams, direct_plays, total_bitrate, by_server } }`
- Auth is a Bearer token (`trr_pub_...`), generated in Settings → API Key

The tile shows Streams / Transcodes / Bandwidth from that one summary call. Includes the repo's standard Skip TLS verification toggle.
