### PR TITLE
Tracearr: shorten livestats tile labels

### DIFF
--- a/Tracearr/Tracearr.php
+++ b/Tracearr/Tracearr.php
@@ -27,7 +27,7 @@ class Tracearr extends \App\SupportedApps implements \App\EnhancedApps
         if ($summary) {
             $data["streams"] = $summary->total;
             $data["transcodes"] = $summary->transcodes;
-            $data["bandwidth"] = $summary->total_bitrate;
+            $data["bandwidth"] = $summary->total > 0 ? $summary->total_bitrate : "0 Mbps";
             if ($summary->total > 0) {
                 $status = "active";
             }

--- a/Tracearr/livestats.blade.php
+++ b/Tracearr/livestats.blade.php
@@ -1,14 +1,14 @@
 <ul class="livestats">
     <li>
-        <span class="title">Streams</span>
+        <span class="title">Total</span>
         <strong>{!! $streams !!}</strong>
     </li>
     <li>
-        <span class="title">Transcodes</span>
+        <span class="title">Tcode</span>
         <strong>{!! $transcodes !!}</strong>
     </li>
     <li>
-        <span class="title">Bandwidth</span>
+        <span class="title">Rate</span>
         <strong>{!! $bandwidth !!}</strong>
     </li>
 </ul>


### PR DESCRIPTION
Follow-up to #981. With three stats on one tile, the full-length uppercase labels (STREAMS/TRANSCODES/BANDWIDTH) overflowed and ran together on the dashboard, confirmed against a live instance, not just a preview.

Relabeled to `Total / Tcode / Rate`

Edit: also fixed bandwidth showing `—` instead of `0 Mbps` when no streams are active (Tracearr's API formats zero bitrate as an em dash; we now normalize it).
