### PR TITLE
Add enhanced Slskd live stats

### DIFF
--- a/Slskd/Slskd.php
+++ b/Slskd/Slskd.php
@@ -2,6 +2,129 @@
 
 namespace App\SupportedApps\Slskd;
 
-class Slskd extends \App\SupportedApps
+class Slskd extends \App\SupportedApps implements \App\EnhancedApps
 {
+    public $config;
+
+    public function test()
+    {
+        $test = parent::appTest($this->url("api/v0/application"), $this->attrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = "inactive";
+        $data = [
+            "health" => "Offline",
+            "downloads" => 0,
+            "uploads" => 0,
+            "down_rate" => "0 B/s",
+            "up_rate" => "0 B/s",
+        ];
+
+        $application = $this->request("api/v0/application");
+        if (!is_object($application) || !isset($application->server)) {
+            return parent::getLiveStats($status, $data);
+        }
+
+        $connected = (bool) ($application->server->isConnected ?? false);
+        $loggedIn = (bool) ($application->server->isLoggedIn ?? false);
+        $data["health"] = $connected && $loggedIn ? "Online" : "Degraded";
+        $status = $connected ? "active" : "inactive";
+
+        [$data["downloads"], $downloadRate] = $this->activeTransfers(
+            $this->request("api/v0/transfers/downloads")
+        );
+        [$data["uploads"], $uploadRate] = $this->activeTransfers(
+            $this->request("api/v0/transfers/uploads")
+        );
+        $data["down_rate"] = $this->formatRate($downloadRate);
+        $data["up_rate"] = $this->formatRate($uploadRate);
+
+        return parent::getLiveStats($status, $data);
+    }
+
+    public function url($endpoint)
+    {
+        return parent::normaliseurl($this->config->url) . $endpoint;
+    }
+
+    private function attrs()
+    {
+        return [
+            "headers" => [
+                "Accept" => "application/json",
+                "X-API-Key" => $this->getSecretConfigValue("apikey"),
+            ],
+        ];
+    }
+
+    private function request($endpoint)
+    {
+        $response = parent::execute($this->url($endpoint), $this->attrs());
+        if (null === $response || 200 !== $response->getStatusCode()) {
+            return null;
+        }
+
+        return json_decode($response->getBody());
+    }
+
+    private function activeTransfers($users)
+    {
+        if (!is_array($users)) {
+            return [0, 0];
+        }
+
+        $count = 0;
+        $rate = 0;
+        foreach ($users as $user) {
+            foreach (($user->directories ?? []) as $directory) {
+                foreach (($directory->files ?? []) as $file) {
+                    if (0 !== strcasecmp((string) ($file->state ?? ""), "InProgress")) {
+                        continue;
+                    }
+                    $count++;
+                    $rate += max(0, (float) ($file->averageSpeed ?? 0));
+                }
+            }
+        }
+
+        return [$count, $rate];
+    }
+
+    private function formatRate($bytes)
+    {
+        $units = ["B/s", "KB/s", "MB/s", "GB/s", "TB/s"];
+        $value = max(0, (float) $bytes);
+        $unit = 0;
+        while ($value >= 1024 && $unit < count($units) - 1) {
+            $value /= 1024;
+            $unit++;
+        }
+
+        $precision = $value >= 100 || 0 === $unit ? 0 : 1;
+        return number_format($value, $precision) . " " . $units[$unit];
+    }
+
+    private function getConfigValue($key, $default = null)
+    {
+        return isset($this->config) && isset($this->config->$key)
+            ? $this->config->$key
+            : $default;
+    }
+
+    private function getSecretConfigValue($key)
+    {
+        $value = (string) $this->getConfigValue($key, "");
+        if (0 !== strpos($value, "enc:")) {
+            return $value;
+        }
+
+        try {
+            return (string) decrypt(substr($value, 4), false);
+        } catch (\Throwable) {
+            return "";
+        }
+    }
 }

--- a/Slskd/app.json
+++ b/Slskd/app.json
@@ -4,7 +4,7 @@
     "website": "https://github.com/slskd/slskd",
     "license": "GNU Affero General Public License v3.0",
     "description": "A modern client-server application for the Soulseek file sharing network.",
-    "enhanced": false,
+    "enhanced": true,
     "tile_background": "dark",
     "icon": "slskd.svg"
 }

--- a/Slskd/config.blade.php
+++ b/Slskd/config.blade.php
@@ -1,0 +1,15 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.apikey') }}</label>
+        {!! Form::input('password', 'config[apikey]', isset($item) ? $item->getconfig()->apikey : null, ['placeholder' => __('app.apps.apikey'), 'data-config' => 'apikey', 'class' => 'form-control config-item']) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+    {!! Form::hidden('config[dataonly]', '1') !!}
+</div>

--- a/Slskd/livestats.blade.php
+++ b/Slskd/livestats.blade.php
@@ -1,0 +1,22 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Health</span>
+        <strong>{!! $health !!}</strong>
+    </li>
+    <li>
+        <span class="title">Down</span>
+        <strong>{!! $downloads !!}</strong>
+    </li>
+    <li>
+        <span class="title">Up</span>
+        <strong>{!! $uploads !!}</strong>
+    </li>
+    <li>
+        <span class="title">Down rate</span>
+        <strong>{!! $down_rate !!}</strong>
+    </li>
+    <li>
+        <span class="title">Up rate</span>
+        <strong>{!! $up_rate !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
## Summary

- add API-key configuration and connectivity test
- show Soulseek connection health, active download/upload counts, and aggregate transfer rates
- use the data-only refresh cadence because the current slskd transfers API returns the complete transfer lists
- accept normal API-key values and optional Laravel-encrypted `enc:` values

## Validation

- `npm test`
- PHP 8.2 syntax check
- PHPCS PSR-12
- live Heimdall config test: successful
- live `/get_stats/{id}`: HTTP 200, active JSON tile with current transfer data