### PR TITLE
Add enhanced Cleanuparr live stats

### DIFF
--- a/Cleanuparr/Cleanuparr.php
+++ b/Cleanuparr/Cleanuparr.php
@@ -2,6 +2,71 @@
 
 namespace App\SupportedApps\Cleanuparr;
 
-class Cleanuparr extends \App\SupportedApps
+class Cleanuparr extends \App\SupportedApps implements \App\EnhancedApps
 {
+    public $config;
+
+    public function test()
+    {
+        $test = parent::appTest($this->url("api/status"));
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = "inactive";
+        $data = [
+            "version" => "N/A",
+            "uptime" => "N/A",
+            "memory" => "N/A",
+            "managers" => 0,
+        ];
+
+        $response = parent::execute($this->url("api/status"));
+        if (null === $response || 200 !== $response->getStatusCode()) {
+            return parent::getLiveStats($status, $data);
+        }
+
+        $details = json_decode($response->getBody());
+        if (!is_object($details) || !isset($details->application)) {
+            return parent::getLiveStats($status, $data);
+        }
+
+        $application = $details->application;
+        $data["version"] = (string) ($application->version ?? "N/A");
+        $data["uptime"] = $this->formatUptime((string) ($application->upTime ?? ""));
+        if (isset($application->memoryUsageMB) && is_numeric($application->memoryUsageMB)) {
+            $data["memory"] = number_format((float) $application->memoryUsageMB, 1) . " MB";
+        }
+
+        foreach (($details->mediaManagers ?? new \stdClass()) as $manager) {
+            $data["managers"] += (int) ($manager->instanceCount ?? 0);
+        }
+        $status = "active";
+
+        return parent::getLiveStats($status, $data);
+    }
+
+    public function url($endpoint)
+    {
+        return parent::normaliseurl($this->config->url) . $endpoint;
+    }
+
+    private function formatUptime($uptime)
+    {
+        if (preg_match('/^(?:(\d+)\.)?(\d+):(\d+):/', $uptime, $matches)) {
+            $days = (int) ($matches[1] ?? 0);
+            $hours = (int) $matches[2];
+            $minutes = (int) $matches[3];
+            if ($days > 0) {
+                return $days . "d " . $hours . "h";
+            }
+            if ($hours > 0) {
+                return $hours . "h " . $minutes . "m";
+            }
+            return $minutes . "m";
+        }
+
+        return $uptime !== "" ? $uptime : "N/A";
+    }
 }

--- a/Cleanuparr/app.json
+++ b/Cleanuparr/app.json
@@ -4,7 +4,7 @@
   "website": "https://github.com/cleanuparr/cleanuparr",
   "license": "GNU General Public License v3.0 or later",
   "description": "Advanced download manager for the Servarr ecosystem",
-  "enhanced": false,
+  "enhanced": true,
   "tile_background": "dark",
   "icon": "cleanuparr.png"
 }

--- a/Cleanuparr/config.blade.php
+++ b/Cleanuparr/config.blade.php
@@ -1,0 +1,11 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+    {!! Form::hidden('config[dataonly]', '1') !!}
+</div>

--- a/Cleanuparr/livestats.blade.php
+++ b/Cleanuparr/livestats.blade.php
@@ -1,0 +1,18 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Version</span>
+        <strong>{!! $version !!}</strong>
+    </li>
+    <li>
+        <span class="title">Uptime</span>
+        <strong>{!! $uptime !!}</strong>
+    </li>
+    <li>
+        <span class="title">Memory</span>
+        <strong>{!! $memory !!}</strong>
+    </li>
+    <li>
+        <span class="title">Managers</span>
+        <strong>{!! $managers !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
## Summary

- add `/api/status` connectivity test
- show version, formatted uptime, memory use, and configured media-manager count
- use the data-only refresh cadence

## Validation

- `npm test`
- PHP 8.2 syntax check
- PHPCS PSR-12
- live Heimdall config test: successful
- live `/get_stats/{id}`: HTTP 200, active JSON tile with current application data