### PR TITLE
Add enhanced Unmanic live stats

### DIFF
--- a/Unmanic/Unmanic.php
+++ b/Unmanic/Unmanic.php
@@ -2,6 +2,67 @@
 
 namespace App\SupportedApps\Unmanic;
 
-class Unmanic extends \App\SupportedApps
+class Unmanic extends \App\SupportedApps implements \App\EnhancedApps
 {
+    public $config;
+
+    protected $method = "POST";
+
+    public function test()
+    {
+        $test = parent::appTest($this->url("api/v2/pending/tasks"), $this->postAttrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = "inactive";
+        $data = [
+            "pending" => 0,
+            "workers" => 0,
+            "completed" => 0,
+        ];
+
+        $pending = $this->request("api/v2/pending/tasks", "POST", $this->postAttrs());
+        if (!is_object($pending) || !isset($pending->recordsTotal)) {
+            return parent::getLiveStats($status, $data);
+        }
+        $data["pending"] = (int) $pending->recordsTotal;
+        $status = "active";
+
+        $workers = $this->request("api/v2/workers/status", "GET");
+        if (is_object($workers) && is_array($workers->workers_status ?? null)) {
+            $data["workers"] = count($workers->workers_status);
+        }
+
+        $history = $this->request("api/v2/history/tasks", "POST", $this->postAttrs());
+        if (is_object($history) && isset($history->recordsTotal)) {
+            $data["completed"] = (int) $history->recordsTotal;
+        }
+
+        return parent::getLiveStats($status, $data);
+    }
+
+    public function url($endpoint)
+    {
+        return parent::normaliseurl($this->config->url) . $endpoint;
+    }
+
+    private function postAttrs()
+    {
+        return [
+            "headers" => ["Accept" => "application/json"],
+            "json" => new \stdClass(),
+        ];
+    }
+
+    private function request($endpoint, $method, $attrs = [])
+    {
+        $response = parent::execute($this->url($endpoint), $attrs, null, $method);
+        if (null === $response || 200 !== $response->getStatusCode()) {
+            return null;
+        }
+
+        return json_decode($response->getBody());
+    }
 }

--- a/Unmanic/app.json
+++ b/Unmanic/app.json
@@ -4,7 +4,7 @@
   "website": "https://docs.unmanic.app/",
   "license": "GNU Affero General Public License v3.0 or later",
   "description": "Unmanic is a simple tool for optimising your file library. You can use it to convert your files into a single, uniform format, manage file movements based on timestamps, or execute custom commands against a file based on its file size.",
-  "enhanced": false,
+  "enhanced": true,
   "tile_background": "dark",
   "icon": "unmanic.png"
 }

--- a/Unmanic/config.blade.php
+++ b/Unmanic/config.blade.php
@@ -1,0 +1,11 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+    {!! Form::hidden('config[dataonly]', '1') !!}
+</div>

--- a/Unmanic/livestats.blade.php
+++ b/Unmanic/livestats.blade.php
@@ -1,0 +1,14 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Pending</span>
+        <strong>{!! $pending !!}</strong>
+    </li>
+    <li>
+        <span class="title">Workers</span>
+        <strong>{!! $workers !!}</strong>
+    </li>
+    <li>
+        <span class="title">Completed</span>
+        <strong>{!! $completed !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
## Summary

- add the Unmanic v2 pending-tasks connectivity test
- show pending task, worker, and completed-history counts
- handle Unmanic's POST task-list endpoints and GET worker-status endpoint independently
- use the data-only refresh cadence

## Validation

- `npm test`
- PHP 8.2 syntax check
- PHPCS PSR-12
- live Heimdall config test: successful
- live `/get_stats/{id}`: HTTP 200, active JSON tile with current worker/task data