### PR TITLE
Add enhanced FOG Project live stats

### DIFF
--- a/FOGProject/FOGProject.php
+++ b/FOGProject/FOGProject.php
@@ -2,6 +2,83 @@
 
 namespace App\SupportedApps\FOGProject;
 
-class FOGProject extends \App\SupportedApps
+class FOGProject extends \App\SupportedApps implements \App\EnhancedApps
 {
+    public $config;
+
+    public function test()
+    {
+        $test = parent::appTest($this->url("system/status"), $this->attrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $status = "inactive";
+        $data = [
+            "hosts" => 0,
+            "tasks" => 0,
+        ];
+
+        $hosts = $this->request("host");
+        if (!is_object($hosts) || !isset($hosts->count)) {
+            return parent::getLiveStats($status, $data);
+        }
+        $data["hosts"] = (int) $hosts->count;
+        $status = "active";
+
+        $tasks = $this->request("task/active");
+        if (is_object($tasks) && isset($tasks->count)) {
+            $data["tasks"] = (int) $tasks->count;
+        }
+
+        return parent::getLiveStats($status, $data);
+    }
+
+    public function url($endpoint)
+    {
+        return parent::normaliseurl($this->config->url) . $endpoint;
+    }
+
+    private function attrs()
+    {
+        return [
+            "headers" => [
+                "Accept" => "application/json",
+                "fog-api-token" => base64_encode($this->getSecretConfigValue("api_token")),
+                "fog-user-token" => base64_encode($this->getSecretConfigValue("user_token")),
+            ],
+        ];
+    }
+
+    private function request($endpoint)
+    {
+        $response = parent::execute($this->url($endpoint), $this->attrs());
+        if (null === $response || 200 !== $response->getStatusCode()) {
+            return null;
+        }
+
+        return json_decode($response->getBody());
+    }
+
+    private function getConfigValue($key, $default = null)
+    {
+        return isset($this->config) && isset($this->config->$key)
+            ? $this->config->$key
+            : $default;
+    }
+
+    private function getSecretConfigValue($key)
+    {
+        $value = (string) $this->getConfigValue($key, "");
+        if (0 !== strpos($value, "enc:")) {
+            return $value;
+        }
+
+        try {
+            return (string) decrypt(substr($value, 4), false);
+        } catch (\Throwable) {
+            return "";
+        }
+    }
 }

--- a/FOGProject/app.json
+++ b/FOGProject/app.json
@@ -4,7 +4,7 @@
     "website": "https://fogproject.org/",
     "license": "GNU General Public License v3.0 or later",
     "description": "A free, open-source network computer cloning and management solution.",
-    "enhanced": false,
+    "enhanced": true,
     "tile_background": "light",
     "icon": "fogproject.png"
 }

--- a/FOGProject/config.blade.php
+++ b/FOGProject/config.blade.php
@@ -1,0 +1,19 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <label>FOG API token</label>
+        {!! Form::input('password', 'config[api_token]', isset($item) ? $item->getconfig()->api_token : null, ['placeholder' => 'FOG API token', 'data-config' => 'api_token', 'class' => 'form-control config-item']) !!}
+    </div>
+    <div class="input">
+        <label>FOG user token</label>
+        {!! Form::input('password', 'config[user_token]', isset($item) ? $item->getconfig()->user_token : null, ['placeholder' => 'FOG user token', 'data-config' => 'user_token', 'class' => 'form-control config-item']) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+    {!! Form::hidden('config[dataonly]', '1') !!}
+</div>

--- a/FOGProject/livestats.blade.php
+++ b/FOGProject/livestats.blade.php
@@ -1,0 +1,10 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Hosts</span>
+        <strong>{!! $hosts !!}</strong>
+    </li>
+    <li>
+        <span class="title">Active tasks</span>
+        <strong>{!! $tasks !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
## Summary

- add standard FOG API and API-enabled user token configuration
- add the authenticated `/system/status` connectivity test
- show registered host and active task counts
- use the data-only refresh cadence
- accept normal token values and optional Laravel-encrypted `enc:` values

## Validation

- `npm test`
- PHP 8.2 syntax check
- PHPCS PSR-12
- live FOG two-token authentication and Heimdall config test: successful
- live `/get_stats/{id}`: HTTP 200, active JSON tile with host/task data