### PR TITLE
Annotate scaffolded classes that cannot be PascalCase

### DIFF
--- a/scripts/lib/stubs.js
+++ b/scripts/lib/stubs.js
@@ -35,6 +35,20 @@ function buildAppJson(a) {
 }
 
 /**
+ * PSR12 requires PascalCase class names, but the class must mirror the folder,
+ * which in turn must mirror the app name (apps.tests.js enforces both). Apps
+ * whose name starts lowercase — alist, pfSense, openHAB, ntfy, oVirt — therefore
+ * cannot satisfy the sniff, and the repo silences it per-class rather than
+ * disabling it everywhere. Emit the same marker so a scaffolded app does not
+ * open a PR that fails PHPCS.
+ * @param {string} folder
+ * @returns {string} "" or the trailing phpcs annotation
+ */
+function classNameSuppression(folder) {
+    return /^[A-Z]/.test(folder) ? "" : " // phpcs:ignore";
+}
+
+/**
  * Foundation PHP class.
  * @param {string} folder
  * @returns {string}
@@ -44,7 +58,7 @@ function foundationPhp(folder) {
 
 namespace App\\SupportedApps\\${folder};
 
-class ${folder} extends \\App\\SupportedApps
+class ${folder} extends \\App\\SupportedApps${classNameSuppression(folder)}
 {
 }
 `;
@@ -60,7 +74,7 @@ function enhancedPhp(folder) {
 
 namespace App\\SupportedApps\\${folder};
 
-class ${folder} extends \\App\\SupportedApps implements \\App\\EnhancedApps
+class ${folder} extends \\App\\SupportedApps implements \\App\\EnhancedApps${classNameSuppression(folder)}
 {
     public $config;
 

--- a/scripts/tests/stubs.test.js
+++ b/scripts/tests/stubs.test.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { foundationPhp, enhancedPhp } = require("../lib/stubs");
+
+// PSR12 wants PascalCase class names, but the class mirrors the folder, which
+// mirrors the app name. Apps named in lowercase (alist, pfSense, ntfy) cannot
+// satisfy the sniff, so the repo silences it on the class line; a scaffolded
+// app has to do the same or it opens a PR that fails PHPCS.
+const classLine = (php) =>
+    php.split("\n").find((l) => l.startsWith("class "));
+
+test("PascalCase folders get no phpcs annotation", () => {
+    assert.equal(
+        classLine(foundationPhp("Netbird")),
+        "class Netbird extends \\App\\SupportedApps"
+    );
+    assert.equal(
+        classLine(enhancedPhp("Netbird")),
+        "class Netbird extends \\App\\SupportedApps implements \\App\\EnhancedApps"
+    );
+});
+
+test("lower-case folders are annotated so PHPCS passes", () => {
+    assert.equal(
+        classLine(foundationPhp("reDirector")),
+        "class reDirector extends \\App\\SupportedApps // phpcs:ignore"
+    );
+    assert.equal(
+        classLine(foundationPhp("ntfy")),
+        "class ntfy extends \\App\\SupportedApps // phpcs:ignore"
+    );
+    assert.equal(
+        classLine(enhancedPhp("oVirt")),
+        "class oVirt extends \\App\\SupportedApps implements " +
+            "\\App\\EnhancedApps // phpcs:ignore"
+    );
+});
+
+test("digit-initial folders are annotated too", () => {
+    // e.g. "2FAuth" -> folder 2FAuth; not a valid PHP-PSR12 PascalCase start.
+    assert.equal(
+        classLine(foundationPhp("2FAuth")),
+        "class 2FAuth extends \\App\\SupportedApps // phpcs:ignore"
+    );
+});
+
+test("stubs remain free of trailing whitespace", () => {
+    for (const php of [
+        foundationPhp("Netbird"),
+        foundationPhp("ntfy"),
+        enhancedPhp("Netbird"),
+        enhancedPhp("ntfy"),
+    ]) {
+        const offenders = php
+            .split("\n")
+            .filter((line) => /[ \t]+$/.test(line));
+        assert.deepEqual(offenders, []);
+    }
+});


### PR DESCRIPTION
## What

Scaffolded apps whose folder does not start with an uppercase letter now get a trailing `// phpcs:ignore` on the class declaration, matching the convention shipped apps already use.

## Why

The generated class and namespace mirror the folder name, and `apps.tests.js` pins the folder to the app name with punctuation stripped:

```js
appJson.name.replaceAll(/[ -.:@]/g, "") === appDirectory
```

So an app whose name starts lowercase gets a class name that PSR12's PascalCase sniff rejects, and there is no way to satisfy both rules at once. The scaffolded PR fails PHPCS before a maintainer ever looks at it — #1014 (`re:Director` → `reDirector`) hit exactly this.

Shipped apps in the same position already carry the annotation:

```php
class alist extends \App\SupportedApps // phpcs:ignore
class pfSense extends \App\SupportedApps // phpcs:ignore
class openHAB extends \App\SupportedApps // phpcs:ignore
class ntfy extends \App\SupportedApps // phpcs:ignore
class oVirt extends \App\SupportedApps implements \App\EnhancedApps // phpcs:ignore
```

Emitting the same marker keeps the sniff enabled everywhere else rather than excluding it repo-wide.

## Tests

New `scripts/tests/stubs.test.js` covers both stub builders: PascalCase folders stay unannotated, lowercase and digit-initial folders get the marker, and the stubs stay free of trailing whitespace. `npm test` is green (36 unit tests, up from 32).