### PR TITLE
Resize oversized icons instead of rejecting the request

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-request.yml
+++ b/.github/ISSUE_TEMPLATE/app-request.yml
@@ -69,8 +69,9 @@ body:
     attributes:
       label: Icon
       description: |
-        Upload a square icon as `.svg` (preferred) or `.png`. PNGs should be
-        between 100 and 300px square. Drag-and-drop or browse to attach the file.
+        Upload a square icon as `.svg` (preferred) or `.png`. PNGs must be at
+        least 100px on each side; anything over 300px is scaled down for you.
+        Drag-and-drop or browse to attach the file.
     validations:
       required: true
       accept: .svg,.png

--- a/.github/workflows/app-request-scaffold.yml
+++ b/.github/workflows/app-request-scaffold.yml
@@ -66,6 +66,32 @@ jobs:
           ICON_PATH: ${{ steps.scaffold.outputs.icon_path }}
         run: npx --yes svgo@3 --config .github/workflows/svgo.config.js "$ICON_PATH"
 
+      # Shrink an oversized PNG to the 300x300 maximum that apps.tests.js
+      # enforces, so a large upload is fixed here instead of being bounced back
+      # to the requester. '>' makes mogrify shrink-only and the fit is
+      # proportional, so a compliant icon is never rewritten -- the same
+      # treatment png-optimize.yml gives PNGs already on master. downloadIcon
+      # has already rejected anything that would fall under the 100x100 minimum
+      # at this size. The path is a fixed, alnum-validated "<Folder>/<icon>",
+      # passed via env and quoted.
+      - name: Resize PNG icon
+        if: steps.scaffold.outputs.ok == 'true' && steps.scaffold.outputs.icon_is_svg == 'false'
+        shell: bash
+        env:
+          ICON_PATH: ${{ steps.scaffold.outputs.icon_path }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
+          read -r w h < <(identify -format '%w %h\n' "$ICON_PATH" | head -n1)
+          if [ "$w" -gt 300 ] || [ "$h" -gt 300 ]; then
+            echo "Resizing $ICON_PATH (${w}x${h} -> fit within 300x300)"
+            mogrify -resize '300x300>' "$ICON_PATH"
+            identify -format 'Now %wx%h\n' "$ICON_PATH" | head -n1
+          else
+            echo "$ICON_PATH is ${w}x${h}; no resize needed."
+          fi
+
       - name: Create Pull Request
         if: steps.scaffold.outputs.ok == 'true'
         id: cpr

--- a/docs/CONTRIBUTING-APPS.md
+++ b/docs/CONTRIBUTING-APPS.md
@@ -16,7 +16,7 @@ A **foundation** app:
 | --- | --- |
 | `app.json` | metadata (see below) |
 | `<Folder>.php` | `class <Folder> extends \App\SupportedApps` |
-| `<slug>.<ext>` | the icon (`.svg` preferred, or `.png` 100-300px) |
+| `<slug>.<ext>` | the icon (`.svg` preferred, or `.png` 100-300px square) |
 
 An **enhanced** app additionally ships:
 

--- a/docs/REQUEST-FLOW.md
+++ b/docs/REQUEST-FLOW.md
@@ -115,6 +115,9 @@ defensively:
 - The icon URL is allow-listed to `https://github.com/user-attachments/assets/…`
   and `https://user-images.githubusercontent.com/…` before download; anything
   else aborts the run with a comment.
-- SVG icons are run through `svgo` before they land in the PR.
+- SVG icons are run through `svgo` before they land in the PR; PNG icons over
+  the 300x300 maximum are scaled down to fit (shrink-only, aspect preserved).
+  A PNG is rejected only when it is under the 100x100 minimum, including when
+  fitting an extreme aspect ratio inside 300x300 would put it there.
 - The validate workflow has only `issues: write`. Only the scaffold workflow —
   gated on the maintainer-applied `approved` label — can write to the repo.

--- a/scripts/lib/download-icon.js
+++ b/scripts/lib/download-icon.js
@@ -10,6 +10,10 @@
  *   - the real file type is determined by magic bytes, not by the URL or a
  *     claimed extension, so a mislabelled payload cannot smuggle in a
  *     non-image (or the wrong image type).
+ *
+ * PNG icons are also dimension-checked. Oversized ones are accepted and resized
+ * during scaffolding; only icons that would still be under the minimum after
+ * that resize are rejected. See downloadIcon for the reasoning.
  */
 
 const { isAllowedAttachmentUrl } = require("./icon-url");
@@ -35,6 +39,30 @@ function pngDimensions(buf) {
         return null;
     }
     return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+/**
+ * Dimensions after fitting inside ICON_MAX_PX square, preserving aspect ratio
+ * and never upscaling — the shape ImageMagick's `-resize '300x300>'` produces,
+ * which is what the scaffold workflow runs on an oversized PNG.
+ *
+ * Rounds *down* so the prediction is never larger than what ImageMagick
+ * actually writes: a caller checking the result against the minimum must not
+ * pass an icon that then lands a pixel short on the runner.
+ *
+ * @param {number} width
+ * @param {number} height
+ * @returns {{width: number, height: number}}
+ */
+function fitWithinMax(width, height) {
+    if (width <= ICON_MAX_PX && height <= ICON_MAX_PX) {
+        return { width, height };
+    }
+    const scale = Math.min(ICON_MAX_PX / width, ICON_MAX_PX / height);
+    return {
+        width: Math.max(1, Math.floor(width * scale)),
+        height: Math.max(1, Math.floor(height * scale)),
+    };
 }
 
 /**
@@ -96,23 +124,31 @@ async function downloadIcon(url, opts = {}) {
         throw new Error("Icon is not a valid PNG or SVG file.");
     }
 
-    // PNGs are dimension-bounded (SVGs scale, so they are exempt). This mirrors
-    // the PR test suite so an oversized icon is rejected here rather than
-    // slipping through to break every open PR.
+    // PNGs are dimension-bounded (SVGs scale, so they are exempt), and
+    // apps.tests.js enforces the same bounds on every PR.
+    //
+    // Only the *minimum* is a hard failure. An icon over the maximum is resized
+    // to fit during scaffolding (see the "Resize PNG icon" step in
+    // app-request-scaffold.yml), so rejecting it here would turn a fixable
+    // request into a round-trip with the requester. What resizing cannot fix is
+    // an extreme aspect ratio: fitting 2000x150 inside 300x300 yields 300x22,
+    // which is below the minimum and needs a differently shaped icon.
     if (ext === ".png") {
         const dim = pngDimensions(buffer);
         if (!dim) {
             throw new Error("Icon PNG header could not be read.");
         }
         const { width, height } = dim;
-        if (width > ICON_MAX_PX || height > ICON_MAX_PX) {
+        const fitted = fitWithinMax(width, height);
+        if (fitted.width < ICON_MIN_PX || fitted.height < ICON_MIN_PX) {
+            const scaled =
+                fitted.width === width && fitted.height === height
+                    ? ""
+                    : ` (${fitted.width}x${fitted.height}px once scaled to fit ` +
+                      `${ICON_MAX_PX}x${ICON_MAX_PX})`;
             throw new Error(
-                `Icon is too large (${width}x${height}px, max ${ICON_MAX_PX}x${ICON_MAX_PX}).`
-            );
-        }
-        if (width < ICON_MIN_PX || height < ICON_MIN_PX) {
-            throw new Error(
-                `Icon is too small (${width}x${height}px, min ${ICON_MIN_PX}x${ICON_MIN_PX}).`
+                `Icon is too small (${width}x${height}px${scaled}, min ` +
+                    `${ICON_MIN_PX}x${ICON_MIN_PX}). Please attach a squarer icon.`
             );
         }
     }
@@ -124,6 +160,7 @@ module.exports = {
     downloadIcon,
     sniffImage,
     pngDimensions,
+    fitWithinMax,
     DEFAULT_MAX_BYTES,
     ICON_MIN_PX,
     ICON_MAX_PX,

--- a/scripts/tests/validation.test.js
+++ b/scripts/tests/validation.test.js
@@ -16,6 +16,7 @@ const {
     sniffImage,
     pngDimensions,
     downloadIcon,
+    fitWithinMax,
     ICON_MIN_PX,
     ICON_MAX_PX,
 } = require("../lib/download-icon");
@@ -170,13 +171,27 @@ test("pngDimensions reads IHDR width/height, null for non-PNG", () => {
     assert.equal(pngDimensions(Buffer.from("short")), null);
 });
 
-test("downloadIcon rejects a PNG over the max dimension", async () => {
-    await assert.rejects(
-        downloadIcon(ATTACHMENT_URL, {
-            fetchImpl: fetchReturning(makePng(ICON_MAX_PX + 1, ICON_MAX_PX + 1)),
-        }),
-        /too large/
-    );
+test("fitWithinMax shrinks to fit, preserves ratio, never upscales", () => {
+    // Already inside the box: returned untouched, never enlarged.
+    assert.deepEqual(fitWithinMax(300, 300), { width: 300, height: 300 });
+    assert.deepEqual(fitWithinMax(120, 100), { width: 120, height: 100 });
+    // Square and rectangular shrinks.
+    assert.deepEqual(fitWithinMax(512, 512), { width: 300, height: 300 });
+    assert.deepEqual(fitWithinMax(1024, 512), { width: 300, height: 150 });
+    assert.deepEqual(fitWithinMax(512, 1024), { width: 150, height: 300 });
+    // Rounds down, so the prediction is never larger than ImageMagick's output.
+    assert.deepEqual(fitWithinMax(1000, 301), { width: 300, height: 90 });
+});
+
+test("downloadIcon accepts an oversized PNG for resizing at scaffold time", async () => {
+    const png = await downloadIcon(ATTACHMENT_URL, {
+        fetchImpl: fetchReturning(makePng(ICON_MAX_PX + 1, ICON_MAX_PX + 1)),
+    });
+    assert.equal(png.ext, ".png");
+    const big = await downloadIcon(ATTACHMENT_URL, {
+        fetchImpl: fetchReturning(makePng(2048, 2048)),
+    });
+    assert.equal(big.ext, ".png");
 });
 
 test("downloadIcon rejects a PNG under the min dimension", async () => {
@@ -185,6 +200,16 @@ test("downloadIcon rejects a PNG under the min dimension", async () => {
             fetchImpl: fetchReturning(makePng(ICON_MIN_PX - 1, ICON_MIN_PX - 1)),
         }),
         /too small/
+    );
+});
+
+test("downloadIcon rejects an icon too lopsided to survive the resize", async () => {
+    // 2000x150 fits to 300x22 -- over the maximum, but resizing cannot save it.
+    await assert.rejects(
+        downloadIcon(ATTACHMENT_URL, {
+            fetchImpl: fetchReturning(makePng(2000, 150)),
+        }),
+        /too small.*once scaled to fit/
     );
 });
 


### PR DESCRIPTION
## What

Oversized PNG icons are now scaled down during scaffolding instead of failing validation. The minimum stays a hard failure.

## Why

`png-optimize.yml` already resizes PNGs over the 300x300 cap:

```bash
mogrify -resize '300x300>' "$f"
```

…but it triggers on `push: branches: [master]`, which is *downstream* of `scripts/lib/download-icon.js`, where the same icons were rejected outright at validation time. So a requester attaching a 512x512 logo was told to go scale it by hand, even though the repo already had the means to do it and would have done so anyway once merged.

#987 (BINDERY) is sitting on exactly this — everything about the request is fine except a 512x512 PNG.

## Changes

- **`app-request-scaffold.yml`** — new `Resize PNG icon` step, mirroring `png-optimize.yml`: shrink-only (`300x300>`), aspect preserved, so a compliant icon is never rewritten. Installs ImageMagick explicitly rather than assuming the runner has it, same as `png-optimize.yml`. Runs before `create-pull-request`, so the PR is compliant on arrival.
- **`download-icon.js`** — no longer throws on the maximum. Adds `fitWithinMax()` and checks the **minimum against post-resize dimensions**, because resizing cannot fix every icon: fitting 2000x150 inside 300x300 yields 300x22. That case now gets a message naming both sizes.
- Docs + issue template updated to match.

## A note on rounding

`fitWithinMax()` rounds **down**; ImageMagick rounds half-up. The prediction is therefore never larger than what actually gets written, so an icon that clears the 100px minimum during validation cannot come out a pixel short on the runner.

## Tests

`npm test` green — 38 unit tests, up from 36:

- `fitWithinMax` shrinks to fit, preserves ratio, never upscales
- oversized PNGs are now accepted (300+1 square, and 2048x2048)
- the lopsided 2000x150 case is still rejected, with the scaled size in the message
- the existing under-minimum rejection is unchanged