### PR TITLE
Enhance Healthchecks with up/down livestats

### DIFF
--- a/Healthchecks/Healthchecks.php
+++ b/Healthchecks/Healthchecks.php
@@ -2,6 +2,69 @@
 
 namespace App\SupportedApps\Healthchecks;
 
-class Healthchecks extends \App\SupportedApps
+class Healthchecks extends \App\SupportedApps implements \App\EnhancedApps
 {
+    public $config;
+
+    public function __construct()
+    {
+    }
+
+    public function test()
+    {
+        $test = parent::appTest($this->url('api/v3/checks/'), $this->getAttrs());
+        echo $test->status;
+    }
+
+    public function livestats()
+    {
+        $data = [
+            'up' => 0,
+            'down' => 0,
+        ];
+
+        // Single authenticated GET. execute() returns null on a failed
+        // connection (it never throws), so guard before reading the body.
+        $res = parent::execute($this->url('api/v3/checks/'), $this->getAttrs());
+        if ($res === null) {
+            return parent::getLiveStats('inactive', $data);
+        }
+
+        // Management API returns { "checks": [ ... ] }; each check has
+        // status of new, up, grace, down, or paused.
+        $body = json_decode($res->getBody());
+        $checks = is_object($body) ? $body->checks : [];
+        if (!is_array($checks)) {
+            return parent::getLiveStats('inactive', $data);
+        }
+
+        foreach ($checks as $check) {
+            if (!isset($check->status)) {
+                continue;
+            }
+            if ($check->status === 'up') {
+                $data['up']++;
+            } elseif ($check->status === 'down') {
+                $data['down']++;
+            }
+        }
+
+        return parent::getLiveStats('inactive', $data);
+    }
+
+    private function getAttrs()
+    {
+        return [
+            'headers' => [
+                'Accept' => 'application/json',
+                'X-Api-Key' => ($this->config->apikey ?? ''),
+            ],
+        ];
+    }
+
+    public function url($endpoint)
+    {
+        $api_url = parent::normaliseurl($this->config->url) . $endpoint;
+        return $api_url;
+    }
 }

--- a/Healthchecks/app.json
+++ b/Healthchecks/app.json
@@ -4,7 +4,7 @@
   "website": "https://healthchecks.io",
   "license": "BSD 3-Clause \"New\" or \"Revised\" License",
   "description": "Instant alerts when your cron jobs fail silently.",
-  "enhanced": false,
+  "enhanced": true,
   "tile_background": "light",
   "icon": "healthchecks.png"
 }

--- a/Healthchecks/config.blade.php
+++ b/Healthchecks/config.blade.php
@@ -1,0 +1,16 @@
+<h2>{{ __('app.apps.config') }} ({{ __('app.optional') }}) @include('items.enable')</h2>
+<div class="items">
+    <div class="input">
+        <label>{{ strtoupper(__('app.url')) }}</label>
+        {!! Form::text('config[override_url]', isset($item) ? $item->getconfig()->override_url : null, ['placeholder' => __('app.apps.override'), 'id' => 'override_url', 'class' => 'form-control']) !!}
+    </div>
+    <div class="input">
+        <label>{{ __('app.apps.apikey') }}</label>
+        {!! Form::text('config[apikey]', isset($item) ? ($item->getconfig()->apikey ?? null) : null, ['placeholder' => __('app.apps.apikey'), 'data-config' => 'apikey', 'class' => 'form-control config-item']) !!}
+    </div>
+    <div class="input">
+        <button style="margin-top: 32px;" class="btn test" id="test_config">Test</button>
+    </div>
+    {{-- Up/down counts change moderately; refresh on the 30s "data only" cadence, not every 5s. --}}
+    {!! Form::hidden('config[dataonly]', '1') !!}
+</div>

--- a/Healthchecks/livestats.blade.php
+++ b/Healthchecks/livestats.blade.php
@@ -1,0 +1,10 @@
+<ul class="livestats">
+    <li>
+        <span class="title">Up</span>
+        <strong>{!! $up ?? 0 !!}</strong>
+    </li>
+    <li>
+        <span class="title">Down</span>
+        <strong>{!! $down ?? 0 !!}</strong>
+    </li>
+</ul>


### PR DESCRIPTION
## Summary

Add enhanced support to the existing Healthchecks app so the tile shows **Up** / **Down** check counts, similar to Uptime Kuma and Kuvasz Uptime. Implementation follows the Kuvasz Uptime pattern closely (JSON list endpoint, API-key header, Up/Down livestats, `dataonly` refresh).

- **Stats (tile):** Up / Down (counts by check `status`)
- **Endpoint:** `GET /api/v3/checks/` for both Test and livestats
- **Auth:** API key via `X-Api-Key` header (read-only keys work)
- **Cadence:** `dataonly=1` — up/down counts refresh on the 30s interval
- **Statuses counted:** `up` and `down` only (`new` / `grace` / `paused` are ignored)

## Test plan

Tested against my self-hosted Healthchecks and Heimdall instances:

- Config Test succeeds with a valid API key and fails with a bad/missing key
- Tile Up/Down counts match `GET /api/v3/checks/`
- Read-only API key works for listing checks